### PR TITLE
Fix scaling of clock counter in the waveslot widgets

### DIFF
--- a/src/wave/waveview.cpp
+++ b/src/wave/waveview.cpp
@@ -461,7 +461,7 @@ void QWaveSlots::paintEvent(QPaintEvent* event)
     int fmheight = 0;
     {
         QFont font = painter.font();
-        font.setPointSize(MainWindow::font() * MainWindow::getScaling() + 0.9);
+        font.setPointSize(MainWindow::font());
         painter.setFont(font);
         fmheight = QFontMetrics(font).overlinePos();
     }


### PR DESCRIPTION
Another scaling fix.

Before:
<img width="295" height="118" alt="image" src="https://github.com/user-attachments/assets/c98d5199-bd82-49d0-b4b6-1781df6cb064" />


After:
<img width="310" height="138" alt="image" src="https://github.com/user-attachments/assets/3ba629dd-a683-4f47-9715-acf3199a6837" />
