### PR TITLE
Horizontal scroll support in wave timeline / Compute Unit view

### DIFF
--- a/src/wave/waveview.cpp
+++ b/src/wave/waveview.cpp
@@ -28,6 +28,7 @@
 #include <QScrollBar>
 #include <QToolTip>
 #include <algorithm>
+#include <cstdlib>
 #include <sstream>
 #include <utility>
 #include "code/qcodelist.h"
@@ -46,6 +47,24 @@ constexpr int64_t SQTT_POINT_MARKER_MIN_CYCLES = 8;
 int markerRowForDepth(int depth, int rows) { return rows - 1 - std::clamp(depth, 0, rows - 1); }
 
 int markerDepthForRow(int row, int rows) { return rows - 1 - std::clamp(row, 0, rows - 1); }
+
+bool horizontalScrollDominates(const QWheelEvent* event)
+{
+    const QPoint& pixel = event->pixelDelta();
+    int dx;
+    int dy;
+    if (!pixel.isNull())
+    {
+        dx = pixel.x();
+        dy = pixel.y();
+    }
+    else
+    {
+        dx = event->angleDelta().x();
+        dy = event->angleDelta().y();
+    }
+    return dx != 0 && std::abs(dx) > std::abs(dy);
+}
 } // namespace
 
 QWaveView::QWaveView(QCustomScroll* parent) : view(parent->view), tool(parent->tool)
@@ -376,13 +395,13 @@ void QWaveSlots::wheelEvent(QWheelEvent* event)
         return;
     }
 
-    // Horizontal scroll: forward to the backing scrollbar, which implements
-    // horizontal scrolling.
-    const bool hasHoriz =
-        event->angleDelta().x() != 0 || (!event->pixelDelta().isNull() && event->pixelDelta().x() != 0);
-    if (hasHoriz)
+    // Horizontal scroll: forward to a single scrollbar. It doesn't matter which
+    // one — ScrollValue::notify() syncs all parents to the same value, so the
+    // others follow. Forwarding to more than one would apply the delta twice.
+    if (horizontalScrollDominates(event))
     {
-        for (auto* parent : view->parents) QApplication::sendEvent(parent->scrollbar, event);
+        if (!view->parents.empty())
+            QApplication::sendEvent(view->parents.front()->scrollbar, event);
         event->accept();
         return;
     }

--- a/src/wave/waveview.cpp
+++ b/src/wave/waveview.cpp
@@ -249,7 +249,7 @@ void QWaveView::leaveEvent(QEvent* event)
 
 void QWaveView::mousePressEvent(QMouseEvent* event)
 {
-    QWARNING(QCodelist::singleton && MainWindow::window, "Invalid codelist", return );
+    QWARNING(QCodelist::singleton && MainWindow::window, "Invalid codelist", return);
 
     if (tool && event->button() & Qt::RightButton)
     {
@@ -361,22 +361,33 @@ void QWaveView::keyPressEvent(QKeyEvent* event)
 
 void QWaveSlots::wheelEvent(QWheelEvent* event)
 {
-    if (!(QApplication::keyboardModifiers() & Qt::ControlModifier))
+    if (QApplication::keyboardModifiers() & Qt::ControlModifier)
     {
-        this->Super::wheelEvent(event);
+        if (!cuwaves_content) return;
+        IMPLEMENT_FPS_LIMITER();
+
+        float mouse_x_in_content = event->position().x() - cuwaves_content->pos().x();
+        int64_t clock_at_mouse = Token::PosToClock(mouse_x_in_content) + view->start;
+
+        // Calculate ratio based on the clock position relative to the visible range
+        float ratio = float(clock_at_mouse - view->start) / float(view->range);
+
+        if (mouse_x_in_content > 0) MainWindow::incrementWaveViewMipmap(event->angleDelta().y() > 0 ? 1 : -1, ratio);
         return;
     }
 
-    if (!cuwaves_content) return;
-    IMPLEMENT_FPS_LIMITER();
+    // Horizontal scroll: forward to the backing scrollbar, which implements
+    // horizontal scrolling.
+    const bool hasHoriz =
+        event->angleDelta().x() != 0 || (!event->pixelDelta().isNull() && event->pixelDelta().x() != 0);
+    if (hasHoriz)
+    {
+        for (auto* parent : view->parents) QApplication::sendEvent(parent->scrollbar, event);
+        event->accept();
+        return;
+    }
 
-    float mouse_x_in_content = event->position().x() - cuwaves_content->pos().x();
-    int64_t clock_at_mouse = Token::PosToClock(mouse_x_in_content) + view->start;
-
-    // Calculate ratio based on the clock position relative to the visible range
-    float ratio = float(clock_at_mouse - view->start) / float(view->range);
-
-    if (mouse_x_in_content > 0) MainWindow::incrementWaveViewMipmap(event->angleDelta().y() > 0 ? 1 : -1, ratio);
+    Super::wheelEvent(event);
 }
 
 void QWaveSlots::keyPressEvent(QKeyEvent* event)
@@ -739,7 +750,7 @@ void QUtilization::ClearOtherSimd()
 
 void QUtilization::AddTokens(int simd, const TokenMap& tokens)
 {
-    QWARNING(simd < 4, "Invalid simd " << simd, return );
+    QWARNING(simd < 4, "Invalid simd " << simd, return);
 
     // Use base here as some decoder versions don't consider stalls for MSG
     // We dont want to show full cycles to avoid clutter in the timeline display


### PR DESCRIPTION
The compute-unit / instruction timeline view (QWaveSlots) already handled Ctrl+vertical-scroll for zoom but silently dropped horizontal scroll events from touchpads and horizontal scroll wheels. This change adds support for horizontal scroll by forwarding horizontal scroll events to the scroll bar of the view, which did handle horizontal scroll events.

## Motivation

Lack of horizontal scroll was the lowest-hanging fruit of my wish-list when using rocprof-compute-viewer.  In writing this I discovered that horizontal scrolling does currently work if your cursor is over the scroll bar, but I think it should work anywhere in the wave view.

## Technical Details

This slightly rearranges existing code in the scroll event handler, and adds logic to forward horizontal scroll events to the scroll bar object.

## Test Plan

This has no automated tests.  It seems like there aren't currently any tests for UI events like this, but I'm not really familiar with the code base and I may be wrong.  It works when I test it manually.  I don't have a lot of experience testing GUI apps like this, so I'm not sure what kind of automated test would be worthwhile.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
