### PR TITLE
trace_decoder: surface inlined call stack into source mapping

### DIFF
--- a/src/data/trace_decoder_emitter.cpp
+++ b/src/data/trace_decoder_emitter.cpp
@@ -464,6 +464,7 @@ void TraceDecoderEmitter::preDisassembleKernels()
 
                 ISALine line;
                 line.text = inst->inst;
+                line.cppline = inst->comment;
                 line.memory_size = inst->size;
                 line.addr = addr;
                 line.codeobj_id = cobj_id;
@@ -553,6 +554,7 @@ rocprofiler_thread_trace_decoder_status_t TraceDecoderEmitter::isaCallback(
 
     ISALine line;
     line.text = inst_text;
+    line.cppline = inst->comment;
     line.memory_size = inst_mem_size;
     line.addr = address.address;
     line.codeobj_id = address.code_object_id;
@@ -755,7 +757,7 @@ void TraceDecoderEmitter::buildCodeFromISACache(const std::vector<CodeData>& cod
                     0,
                     0,
                     isa_line.text,
-                    "",
+                    isa_line.cppline,
                     std::vector<int64_t>()
                 ));
             }

--- a/src/data/trace_decoder_emitter.h
+++ b/src/data/trace_decoder_emitter.h
@@ -54,6 +54,7 @@ private:
     struct ISALine
     {
         std::string text;
+        std::string cppline;
         uint64_t memory_size = 0;
         uint64_t addr = 0;
         uint64_t codeobj_id = 0;


### PR DESCRIPTION
ASMLine already splits the per-instruction Source field on " -> " and registers the instruction under every inline frame (src/code/asmcode.cpp), and shows the full stack in the hover tooltip. But the trace_decoder path (live COMGR disassembly, no code.json) never populated the multi-frame string: ISALine had no cppline and buildCodeFromISACache() passed "" for the ISA-only rows.

The codeobj decoder already builds the full inlined call stack ("innermost -> ... -> kernel", from DW_TAG_inlined_subroutine) in rocprof_trace_decoder::codeobj::Instruction::comment. Wire that comment into ISALine.cppline and through to CodeData, so clicking a caller line (e.g. a helper call site) highlights the inlined instructions and the call-stack tooltip works for trace_decoder inputs.

No UI / data-structure / serialization changes; the JSON path is unaffected (it already reads code.json's Source field).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
