### PR TITLE
Fix performance of events in global view

### DIFF
--- a/src/analysis/hidden_latency.cpp
+++ b/src/analysis/hidden_latency.cpp
@@ -243,6 +243,10 @@ bool analyzeScoped(DataStore& store, int SE, int SIMD)
         QWARNING(false, "failed to analyze waves", return false);
     }
 
+    if (auto it = store.other_simd_by_se.find(SE); it != store.other_simd_by_se.end())
+        for (const auto& rec : it->second)
+            if (rec.cycles > 0) vmem.push_back({rec.time, rec.cycles});
+
     wmma = compute_util(wmma);
     valu = compute_util(valu);
     vmem = compute_util(vmem);

--- a/src/data/record_handlers.cpp
+++ b/src/data/record_handlers.cpp
@@ -50,6 +50,7 @@ void OccupancyHandler::onOccupancy(int se, const occupancy_record_t& rec) { stor
 
 void OccupancyHandler::onParsingComplete()
 {
+    auto by_time = [](const auto& a, const auto& b) { return a.time < b.time; };
     for (auto& [se, records] : store.occupancy_by_se)
         std::sort(
             records.begin(),
@@ -60,6 +61,8 @@ void OccupancyHandler::onParsingComplete()
                 return a.start < b.start;
             }
         );
+    for (auto& [se, records] : store.trace_events_by_se) std::stable_sort(records.begin(), records.end(), by_time);
+    for (auto& [se, records] : store.dispatch_records_by_se) std::stable_sort(records.begin(), records.end(), by_time);
 }
 
 void OccupancyHandler::onTraceEvent(int se, const trace_event_record_t& rec)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -27,6 +27,7 @@
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QFontDatabase>
+#include <QHBoxLayout>
 #include <QMessageBox>
 #include <QPainterPath>
 #include <QScrollArea>
@@ -75,6 +76,7 @@
 #include "summary/summaryview.h"
 #include "util/version.h"
 #include "wave/othersimd.h"
+#include "wave/overlay_utils.h"
 #include "wave/scroll.h"
 #include "wave/waveglobal.h"
 #include "wave/waveview.h"
@@ -1731,6 +1733,34 @@ void MainWindow::CreateGlobalView()
         global_view_widget = new QGlobalView(*data_store);
     else
         global_view_widget = new QGlobalView(GetUIDir() + "occupancy.json");
+
+    auto* eventFilter = new QWidget(this);
+    auto* eventFilterLayout = new QHBoxLayout(eventFilter);
+    eventFilterLayout->setContentsMargins(6, 2, 6, 2);
+    eventFilterLayout->setSpacing(10);
+    auto addEventFilter = [&](const char* label, uint32_t group)
+    {
+        auto* checkbox = new QCheckBox(label, eventFilter);
+        checkbox->setChecked(global_view_widget->DecoderEventGroups() & group);
+        connect(
+            checkbox,
+            &QCheckBox::toggled,
+            this,
+            [this, group](bool checked)
+            {
+                uint32_t groups = global_view_widget->DecoderEventGroups();
+                global_view_widget->SetDecoderEventGroups(checked ? (groups | group) : (groups & ~group));
+            }
+        );
+        eventFilterLayout->addWidget(checkbox);
+    };
+    addEventFilter("Dispatches", WaveOverlay::DecoderEventGroupDispatch);
+    addEventFilter("Flush events", WaveOverlay::DecoderEventGroupFlush);
+    addEventFilter("Code object", WaveOverlay::DecoderEventGroupCodeObject);
+    addEventFilter("SQTT", WaveOverlay::DecoderEventGroupSQTT);
+    addEventFilter("Others", WaveOverlay::DecoderEventGroupOther);
+    eventFilterLayout->addStretch();
+    mainLayout->addWidget(eventFilter);
 
     // Load shaderdata from multiple threads before setting up the view
     // (shaderdata_manager is already loaded in ResetSelector, just pass to global view)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -28,6 +28,7 @@
 #include <QFileInfo>
 #include <QFontDatabase>
 #include <QHBoxLayout>
+#include <QLabel>
 #include <QMessageBox>
 #include <QPainterPath>
 #include <QScrollArea>
@@ -1735,9 +1736,12 @@ void MainWindow::CreateGlobalView()
         global_view_widget = new QGlobalView(GetUIDir() + "occupancy.json");
 
     auto* eventFilter = new QWidget(this);
+    eventFilter->setMinimumWidth(0);
+    eventFilter->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
     auto* eventFilterLayout = new QHBoxLayout(eventFilter);
     eventFilterLayout->setContentsMargins(6, 2, 6, 2);
     eventFilterLayout->setSpacing(10);
+    eventFilterLayout->addWidget(new QLabel("Event filter:", eventFilter));
     auto addEventFilter = [&](const char* label, uint32_t group)
     {
         auto* checkbox = new QCheckBox(label, eventFilter);
@@ -1758,6 +1762,7 @@ void MainWindow::CreateGlobalView()
     addEventFilter("Flush events", WaveOverlay::DecoderEventGroupFlush);
     addEventFilter("Code object", WaveOverlay::DecoderEventGroupCodeObject);
     addEventFilter("SQTT", WaveOverlay::DecoderEventGroupSQTT);
+    addEventFilter("GC Rinse", WaveOverlay::DecoderEventGroupGCRinse);
     addEventFilter("Others", WaveOverlay::DecoderEventGroupOther);
     eventFilterLayout->addStretch();
     mainLayout->addWidget(eventFilter);

--- a/src/wave/overlay_utils.h
+++ b/src/wave/overlay_utils.h
@@ -23,10 +23,12 @@
 #pragma once
 
 #include <QPainter>
+#include <algorithm>
 #include <cstdint>
 #include <sstream>
 #include <string>
 #include <vector>
+#include "config/config.hpp"
 #include "data/marker_colors.h"
 #include "data/records.h"
 
@@ -35,14 +37,43 @@ namespace WaveOverlay
 inline constexpr int DecoderDispatchWidth = 5;
 inline constexpr int DecoderEventWidth = 4;
 
+inline constexpr uint32_t DecoderEventGroupDispatch = 1u << 0;
+inline constexpr uint32_t DecoderEventGroupFlush = 1u << 1;
+inline constexpr uint32_t DecoderEventGroupCodeObject = 1u << 2;
+inline constexpr uint32_t DecoderEventGroupSQTT = 1u << 3;
+inline constexpr uint32_t DecoderEventGroupOther = 1u << 4;
+inline constexpr uint32_t DecoderEventAllGroups = DecoderEventGroupDispatch | DecoderEventGroupFlush |
+                                                  DecoderEventGroupCodeObject | DecoderEventGroupSQTT |
+                                                  DecoderEventGroupOther;
+
 enum class DecoderEventSurface
 {
     ComputeUnit,
     Global,
 };
 
-inline bool showTraceEvent(const trace_event_record_t& event, DecoderEventSurface surface)
+inline uint32_t traceEventGroup(int type)
 {
+    switch (type)
+    {
+        case ROCPROF_TRACE_DECODER_EVENT_GC_RINSE:
+        case ROCPROF_TRACE_DECODER_EVENT_CS_PARTIAL_FLUSH:
+        case ROCPROF_TRACE_DECODER_EVENT_CACHE_FLUSH:
+        case ROCPROF_TRACE_DECODER_EVENT_BOTTOM_OF_PIPE_TS: return DecoderEventGroupFlush;
+        case ROCPROF_TRACE_DECODER_EVENT_CODE_OBJECT_LOAD:
+        case ROCPROF_TRACE_DECODER_EVENT_CODE_OBJECT_UNLOAD: return DecoderEventGroupCodeObject;
+        case ROCPROF_TRACE_DECODER_EVENT_TT_STALL_BEGIN:
+        case ROCPROF_TRACE_DECODER_EVENT_TT_STALL_END:
+        case ROCPROF_TRACE_DECODER_EVENT_TT_FLUSH: return DecoderEventGroupSQTT;
+        default: return DecoderEventGroupOther;
+    }
+}
+
+inline bool showTraceEvent(
+    const trace_event_record_t& event, DecoderEventSurface surface, uint32_t groups = DecoderEventAllGroups
+)
+{
+    if ((traceEventGroup(event.type) & groups) == 0) return false;
     switch (surface)
     {
         case DecoderEventSurface::ComputeUnit:
@@ -50,24 +81,34 @@ inline bool showTraceEvent(const trace_event_record_t& event, DecoderEventSurfac
                    event.type != ROCPROF_TRACE_DECODER_EVENT_CODE_OBJECT_LOAD &&
                    event.type != ROCPROF_TRACE_DECODER_EVENT_CODE_OBJECT_UNLOAD &&
                    event.type != ROCPROF_TRACE_DECODER_EVENT_CS_PARTIAL_FLUSH;
-        case DecoderEventSurface::Global:
-            return event.type != ROCPROF_TRACE_DECODER_EVENT_DIDT_STALL_BEGIN &&
-                   event.type != ROCPROF_TRACE_DECODER_EVENT_DIDT_STALL_END &&
-                   event.type != ROCPROF_TRACE_DECODER_EVENT_SPM_SAMPLE;
+        case DecoderEventSurface::Global: return true;
     }
     return true;
 }
 
-template <typename Record> int findRecordIndexAt(
-    const std::vector<Record>* records, int64_t clock, int64_t tolerance, bool prefer_later_on_tie = false
+template <typename Record> auto eventLowerBound(const std::vector<Record>& records, int64_t clock)
+{
+    return std::lower_bound(
+        records.begin(), records.end(), clock, [](const Record& record, int64_t value) { return record.time < value; }
+    );
+}
+
+template <typename Record, typename Predicate> int findRecordIndexAtIf(
+    const std::vector<Record>* records,
+    int64_t clock,
+    int64_t tolerance,
+    Predicate predicate,
+    bool prefer_later_on_tie = false
 )
 {
     if (!records || records->empty()) return -1;
 
     int best = -1;
     int64_t best_dist = tolerance + 1;
-    for (auto it = records->begin(); it != records->end(); ++it)
+    for (auto it = eventLowerBound(*records, clock - tolerance); it != records->end() && it->time <= clock + tolerance;
+         ++it)
     {
+        if (!predicate(*it)) continue;
         const int64_t dist = it->time > clock ? it->time - clock : clock - it->time;
         if (dist < best_dist || (prefer_later_on_tie && dist == best_dist))
         {
@@ -76,6 +117,13 @@ template <typename Record> int findRecordIndexAt(
         }
     }
     return best;
+}
+
+template <typename Record> int findRecordIndexAt(
+    const std::vector<Record>* records, int64_t clock, int64_t tolerance, bool prefer_later_on_tie = false
+)
+{
+    return findRecordIndexAtIf(records, clock, tolerance, [](const Record&) { return true; }, prefer_later_on_tie);
 }
 
 template <typename Record> const Record* findRecordAt(
@@ -121,7 +169,8 @@ template <typename ClockToPixel> void drawDecoderEvents(
     int64_t clock_start,
     int64_t clock_end,
     int height,
-    ClockToPixel clock_to_pixel
+    ClockToPixel clock_to_pixel,
+    uint32_t event_groups = DecoderEventAllGroups
 )
 {
     auto draw_line = [&](int64_t time, const QColor& color, int width)
@@ -135,14 +184,19 @@ template <typename ClockToPixel> void drawDecoderEvents(
     };
 
     painter.save();
-    if (dispatch_records)
-        for (const auto& dispatch : *dispatch_records)
-            draw_line(dispatch.time, WindowColors::DecoderDispatchEventColor(), DecoderDispatchWidth);
+    if (dispatch_records && (event_groups & DecoderEventGroupDispatch))
+        for (auto it = eventLowerBound(*dispatch_records, clock_start); it != dispatch_records->end(); ++it)
+        {
+            if (it->time > clock_end) break;
+            draw_line(it->time, WindowColors::DecoderDispatchEventColor(), DecoderDispatchWidth);
+        }
 
     if (trace_events)
-        for (const auto& event : *trace_events)
+        for (auto it = eventLowerBound(*trace_events, clock_start); it != trace_events->end(); ++it)
         {
-            if (!showTraceEvent(event, surface)) continue;
+            if (it->time > clock_end) break;
+            const auto& event = *it;
+            if (!showTraceEvent(event, surface, event_groups)) continue;
             draw_line(event.time, WindowColors::DecoderEventColor(event.type), DecoderEventWidth);
         }
     painter.restore();

--- a/src/wave/overlay_utils.h
+++ b/src/wave/overlay_utils.h
@@ -41,10 +41,12 @@ inline constexpr uint32_t DecoderEventGroupDispatch = 1u << 0;
 inline constexpr uint32_t DecoderEventGroupFlush = 1u << 1;
 inline constexpr uint32_t DecoderEventGroupCodeObject = 1u << 2;
 inline constexpr uint32_t DecoderEventGroupSQTT = 1u << 3;
-inline constexpr uint32_t DecoderEventGroupOther = 1u << 4;
+inline constexpr uint32_t DecoderEventGroupGCRinse = 1u << 4;
+inline constexpr uint32_t DecoderEventGroupOther = 1u << 5;
 inline constexpr uint32_t DecoderEventAllGroups = DecoderEventGroupDispatch | DecoderEventGroupFlush |
                                                   DecoderEventGroupCodeObject | DecoderEventGroupSQTT |
-                                                  DecoderEventGroupOther;
+                                                  DecoderEventGroupGCRinse | DecoderEventGroupOther;
+inline constexpr uint32_t DecoderEventDefaultGlobalGroups = DecoderEventAllGroups & ~DecoderEventGroupGCRinse;
 
 enum class DecoderEventSurface
 {
@@ -56,7 +58,7 @@ inline uint32_t traceEventGroup(int type)
 {
     switch (type)
     {
-        case ROCPROF_TRACE_DECODER_EVENT_GC_RINSE:
+        case ROCPROF_TRACE_DECODER_EVENT_GC_RINSE: return DecoderEventGroupGCRinse;
         case ROCPROF_TRACE_DECODER_EVENT_CS_PARTIAL_FLUSH:
         case ROCPROF_TRACE_DECODER_EVENT_CACHE_FLUSH:
         case ROCPROF_TRACE_DECODER_EVENT_BOTTOM_OF_PIPE_TS: return DecoderEventGroupFlush;
@@ -123,7 +125,9 @@ template <typename Record> int findRecordIndexAt(
     const std::vector<Record>* records, int64_t clock, int64_t tolerance, bool prefer_later_on_tie = false
 )
 {
-    return findRecordIndexAtIf(records, clock, tolerance, [](const Record&) { return true; }, prefer_later_on_tie);
+    return findRecordIndexAtIf(
+        records, clock, tolerance, [](const Record&) { return true; }, prefer_later_on_tie
+    );
 }
 
 template <typename Record> const Record* findRecordAt(

--- a/src/wave/waveglobal.cpp
+++ b/src/wave/waveglobal.cpp
@@ -44,7 +44,7 @@ int64_t QGlobalView::begintime = 0;
 int64_t QGlobalView::maxtime = 0;
 int QGlobalView::mipmap_level = 10;
 int QGlobalView::height_scale = 4;
-uint32_t QGlobalView::decoder_event_groups = WaveOverlay::DecoderEventAllGroups;
+uint32_t QGlobalView::decoder_event_groups = WaveOverlay::DecoderEventDefaultGlobalGroups;
 
 // Column positions for SE|SA|CU|SM labels
 static constexpr int COL_SE = 3;

--- a/src/wave/waveglobal.cpp
+++ b/src/wave/waveglobal.cpp
@@ -44,6 +44,7 @@ int64_t QGlobalView::begintime = 0;
 int64_t QGlobalView::maxtime = 0;
 int QGlobalView::mipmap_level = 10;
 int QGlobalView::height_scale = 4;
+uint32_t QGlobalView::decoder_event_groups = WaveOverlay::DecoderEventAllGroups;
 
 // Column positions for SE|SA|CU|SM labels
 static constexpr int COL_SE = 3;
@@ -536,12 +537,7 @@ QGlobalView::QGlobalView(DataStore& store)
     for (const auto& [se, records] : store.trace_events_by_se)
     {
         auto sorted = std::make_shared<std::vector<trace_event_record_t>>();
-        sorted->reserve(records.size());
-        for (const auto& record : records)
-        {
-            if (WaveOverlay::showTraceEvent(record, WaveOverlay::DecoderEventSurface::Global))
-                sorted->push_back(record);
-        }
+        *sorted = records;
         std::sort(
             sorted->begin(),
             sorted->end(),
@@ -673,6 +669,12 @@ void QGlobalView::populateLabelPanel()
     // MainWindow), the extra-height info on each view is already known but
     // wasn't applied because rows didn't exist yet. Re-sync now.
     syncLabelPanelExtraHeights();
+}
+
+void QGlobalView::SetDecoderEventGroups(uint32_t groups)
+{
+    decoder_event_groups = groups;
+    for (auto* view : views) view->update();
 }
 
 void QGlobalView::paintEvent(QPaintEvent* event)
@@ -955,18 +957,30 @@ void QOutsideWaveView::DrawDecoderEvents(QPainter& painter, const QRect& area)
         visible_clock_start,
         visible_clock_end,
         row_h,
-        [](int64_t time) { return QGlobalView::ClockToPos(time); }
+        [](int64_t time) { return QGlobalView::ClockToPos(time); },
+        QGlobalView::DecoderEventGroups()
     );
 }
 
 int QOutsideWaveView::FindTraceEventAt(int64_t clock_pos) const
 {
     const int64_t tol = std::max<int64_t>(QGlobalView::Delta() * 4, 4);
-    return WaveOverlay::findRecordIndexAt(trace_events.get(), clock_pos, tol);
+    return WaveOverlay::findRecordIndexAtIf(
+        trace_events.get(),
+        clock_pos,
+        tol,
+        [](const trace_event_record_t& event)
+        {
+            return WaveOverlay::showTraceEvent(
+                event, WaveOverlay::DecoderEventSurface::Global, QGlobalView::DecoderEventGroups()
+            );
+        }
+    );
 }
 
 int QOutsideWaveView::FindDispatchAt(int64_t clock_pos) const
 {
+    if ((QGlobalView::DecoderEventGroups() & WaveOverlay::DecoderEventGroupDispatch) == 0) return -1;
     const int64_t tol = std::max<int64_t>(QGlobalView::Delta() * 4, 4);
     return WaveOverlay::findRecordIndexAt(dispatch_records.get(), clock_pos, tol);
 }
@@ -1042,13 +1056,23 @@ void QOutsideWaveView::paintEvent(QPaintEvent* event)
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing);
 
+    const QRect area = event->rect();
+    const int64_t visible_clock_start = QGlobalView::PosToClock(area.left());
+    const int64_t visible_clock_end = QGlobalView::PosToClock(area.right());
     int64_t leftover = 0;
     int64_t end_clock = 0;
-    for (auto& wave : waves)
+    auto it = std::lower_bound(
+        waves.begin(),
+        waves.end(),
+        visible_clock_start,
+        [](const WaveTraceData& wave, int64_t clock) { return wave.end < clock; }
+    );
+    for (; it != waves.end() && it->begin <= visible_clock_end; ++it)
     {
+        const auto& wave = *it;
         if (end_clock + QGlobalView::Delta() < wave.begin) leftover = 0;
 
-        leftover = this->DrawWave(painter, wave.begin - leftover, wave, event->rect());
+        leftover = this->DrawWave(painter, wave.begin - leftover, wave, area);
 
         if (leftover == 0) end_clock = wave.end;
     }
@@ -1175,12 +1199,18 @@ void QOutsideWaveView::mouseMoveEvent(QMouseEvent* event)
         return;
     }
 
-    int index = 0;
-    while (index < waves.size() && waves[index].end < clock_pos) index++;
+    auto wave_it = std::upper_bound(
+        waves.begin(),
+        waves.end(),
+        clock_pos,
+        [](int64_t clock, const WaveTraceData& wave) { return clock < wave.begin; }
+    );
+    if (wave_it == waves.begin()) return;
+    --wave_it;
+    if (wave_it->end < clock_pos) return;
 
-    if (index >= waves.size() || waves[index].begin > clock_pos) return;
-
-    const auto& wave = waves[index];
+    const int index = static_cast<int>(wave_it - waves.begin());
+    const auto& wave = *wave_it;
     std::stringstream tooltip;
     tooltip << "SE:" << se << "  SA:" << sa << "  CU:" << cu << "  SIMD:" << simd << "  SLOT:" << slot
             << "  ID:" << index << "\nBegin: " << wave.begin << "  End: " << wave.end

--- a/src/wave/waveglobal.h
+++ b/src/wave/waveglobal.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <QWidget>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <unordered_set>
@@ -241,6 +242,7 @@ public:
 
     static int GetMip() { return mipmap_level; }
     static int SpinToMip(int spinValue) { return std::max(0, std::min(15 - spinValue, 15)); }
+    static uint32_t DecoderEventGroups() { return decoder_event_groups; }
 
     // Calculate new scroll position when zooming, keeping anchor_x at the same viewport position
     static int calcZoomScroll(int old_mip, int new_mip, int old_scroll, int anchor_viewport_x);
@@ -269,6 +271,7 @@ private:
     static int64_t begintime;
     static int mipmap_level;
     static int height_scale;
+    static uint32_t decoder_event_groups;
     std::vector<QOutsideWaveView*> views;
     QScrollArea* m_scrollArea = nullptr;
 
@@ -277,6 +280,7 @@ public:
     QLabelPanel* labelPanel = nullptr;   // External label panel for sticky labels
     void setScrollArea(QScrollArea* sa); // Connect to scroll area for sync
     void populateLabelPanel();           // Fill labelPanel with label data
+    void SetDecoderEventGroups(uint32_t groups);
 
     /// Distribute pre-loaded shaderdata records to matching wave views.
     void SetShaderData(const ShaderDataManager& manager);


### PR DESCRIPTION
## Motivation

The global view's performance scales terrible with number of waves total, plus number of events in screen. Adding:
* Faster event and wave lookup
* Event filters in the Global View display

Also, other_simd was missing from the utilization calculation, so added here.

## JIRA ID

AIPROFSDK-925
