### PR TITLE
Fix QT5 build.

### DIFF
--- a/src/collection/flamegraphwidget.cpp
+++ b/src/collection/flamegraphwidget.cpp
@@ -407,7 +407,11 @@ void FlameGraphWidget::mouseMoveEvent(QMouseEvent* event)
 
         if (hovered)
             QToolTip::showText(
-                event->globalPosition().toPoint(),
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+                event->globalPos(),
+#else
+                event->globalPosition()toPoint(),
+#endif
                 formatFrameTooltip(*hovered, m_allTotalLatency, m_allNonhiddenLatency),
                 this
             );

--- a/src/collection/flamegraphwidget.cpp
+++ b/src/collection/flamegraphwidget.cpp
@@ -410,7 +410,7 @@ void FlameGraphWidget::mouseMoveEvent(QMouseEvent* event)
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
                 event->globalPos(),
 #else
-                event->globalPosition()toPoint(),
+                event->globalPosition().toPoint(),
 #endif
                 formatFrameTooltip(*hovered, m_allTotalLatency, m_allNonhiddenLatency),
                 this


### PR DESCRIPTION
## Motivation

rocprof-compute-viewer supports both QT5 and QT6, however, building for QT5 was broken.

## Technical Details

Don't use QT6 function when using QT5.

## Test Plan

Before: compiler error.

After: project builds.

## Test Result

Now builds correctly.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
