### PR TITLE
Remember the last import directory

### DIFF
--- a/src/config/appconfig.cpp
+++ b/src/config/appconfig.cpp
@@ -22,7 +22,20 @@
 
 #include "appconfig.h"
 #include <QDir>
+#include <QFileInfo>
 #include <QStandardPaths>
+
+namespace
+{
+QString existingDirectory(const QString& path)
+{
+    if (path.isEmpty()) return {};
+
+    QFileInfo info(QDir::cleanPath(path));
+    if (!info.exists()) return {};
+    return info.isDir() ? info.absoluteFilePath() : info.absolutePath();
+}
+} // namespace
 
 AppConfig& AppConfig::getInstance()
 {
@@ -79,6 +92,26 @@ void AppConfig::setSeparateLDSPipe(bool enabled) { settings.setValue("DisplayOpt
 bool AppConfig::getShowIdleTime() const { return settings.value("DisplayOptions/ShowIdleTime", true).toBool(); }
 
 void AppConfig::setShowIdleTime(bool enabled) { settings.setValue("DisplayOptions/ShowIdleTime", enabled); }
+
+// Import Options
+QString AppConfig::getLastImportDirectory(const QString& fallback) const
+{
+    const QString saved = existingDirectory(settings.value("ImportOptions/LastDirectory").toString());
+    if (!saved.isEmpty()) return saved;
+
+    const QString fallback_dir = existingDirectory(fallback);
+    if (!fallback_dir.isEmpty()) return fallback_dir;
+
+    const QString documents =
+        existingDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+    return documents.isEmpty() ? QDir::homePath() : documents;
+}
+
+void AppConfig::setLastImportDirectory(const QString& path)
+{
+    const QString directory = existingDirectory(path);
+    if (!directory.isEmpty()) settings.setValue("ImportOptions/LastDirectory", directory);
+}
 
 // Instruction Column Visibility
 bool AppConfig::getColumnVisible(int element, bool bDefault) const

--- a/src/config/appconfig.h
+++ b/src/config/appconfig.h
@@ -55,6 +55,10 @@ public:
     bool getShowIdleTime() const;
     void setShowIdleTime(bool enabled);
 
+    // Import Options
+    QString getLastImportDirectory(const QString& fallback = {}) const;
+    void setLastImportDirectory(const QString& path);
+
     // Instruction Column Visibility (uses ASMCodeline::Element values)
     bool getColumnVisible(int element, bool bDefault = true) const;
     void setColumnVisible(int element, bool enabled);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -792,9 +792,13 @@ bool MainWindow::runHiddenLatencyAnalysis(bool show_dialogs)
 
 void MainWindow::SetJsonsFolder()
 {
-    std::string jsons_dir = QFileDialog::getExistingDirectory(this, "Select Dir", ui_dir.c_str()).toStdString();
-    if (jsons_dir.empty()) return;
-    current_path = jsons_dir;
+    AppConfig& config = AppConfig::getInstance();
+    const QString start_dir = config.getLastImportDirectory(QString::fromStdString(ui_dir));
+    const QString jsons_dir = QFileDialog::getExistingDirectory(this, "Select Dir", start_dir);
+    if (jsons_dir.isEmpty()) return;
+
+    config.setLastImportDirectory(jsons_dir);
+    current_path = jsons_dir.toStdString();
     ResetSelector();
 }
 
@@ -809,10 +813,14 @@ void MainWindow::OpenAttFiles()
     );
     return;
 #else
+    AppConfig& config = AppConfig::getInstance();
+    const QString start_dir = config.getLastImportDirectory(QString::fromStdString(ui_dir));
     QStringList picked = QFileDialog::getOpenFileNames(
-        this, "Select ATT Trace Files", ui_dir.c_str(), "ATT Trace Files (*.att);;All Files (*)"
+        this, "Select ATT Trace Files", start_dir, "ATT Trace Files (*.att);;All Files (*)"
     );
     if (picked.isEmpty()) return;
+
+    config.setLastImportDirectory(picked.front());
 
     InputInfo info;
     info.type = InputType::ATT_FILES;
@@ -853,10 +861,14 @@ void MainWindow::OpenRocpd()
     );
     return;
 #else
+    AppConfig& config = AppConfig::getInstance();
+    const QString start_dir = config.getLastImportDirectory(QString::fromStdString(ui_dir));
     QString picked = QFileDialog::getOpenFileName(
-        this, "Select ROCpd Database", ui_dir.c_str(), "ROCpd Database (*.rocpd);;All Files (*)"
+        this, "Select ROCpd Database", start_dir, "ROCpd Database (*.rocpd);;All Files (*)"
     );
     if (picked.isEmpty()) return;
+
+    config.setLastImportDirectory(picked);
 
     InputInfo info;
     info.type = InputType::ROCPD;

--- a/tests/widgets/CMakeLists.txt
+++ b/tests/widgets/CMakeLists.txt
@@ -26,6 +26,16 @@ add_test(NAME color_test COMMAND color_test)
 set_tests_properties(color_test PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
 
 # ============================================================================
+# AppConfig Tests - persistent import-directory selection and fallback behavior
+# ============================================================================
+add_executable(appconfig_test appconfig_test.cpp ${SRC_DIR}/config/appconfig.cpp)
+target_include_directories(appconfig_test PRIVATE ${SRC_DIR})
+target_link_libraries(appconfig_test GTest::gtest Qt6::Core)
+rcv_enable_asan(appconfig_test)
+add_test(NAME appconfig_test COMMAND appconfig_test)
+set_tests_properties(appconfig_test PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+
+# ============================================================================
 # PlotCurve Tests - LOD curve data structures and PlotCurve with LOD generation
 # ============================================================================
 add_executable(plotcurve_test plotcurve_test.cpp)

--- a/tests/widgets/appconfig_test.cpp
+++ b/tests/widgets/appconfig_test.cpp
@@ -1,0 +1,105 @@
+// MIT License
+//
+// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <gtest/gtest.h>
+#include <QDir>
+#include <QFile>
+#include <QSettings>
+#include <QTemporaryDir>
+#include "config/appconfig.h"
+
+class AppConfigTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        QSettings settings("AMD", "Rocprof-Compute-Viewer");
+        settings.clear();
+    }
+};
+
+TEST_F(AppConfigTest, UsesExistingFallbackWithoutSavedDirectory)
+{
+    QTemporaryDir fallback;
+    ASSERT_TRUE(fallback.isValid());
+
+    EXPECT_EQ(
+        AppConfig::getInstance().getLastImportDirectory(fallback.path()),
+        QDir::cleanPath(fallback.path())
+    );
+}
+
+TEST_F(AppConfigTest, RemembersSelectedDirectory)
+{
+    QTemporaryDir selected;
+    ASSERT_TRUE(selected.isValid());
+
+    AppConfig::getInstance().setLastImportDirectory(selected.path());
+
+    EXPECT_EQ(
+        AppConfig::getInstance().getLastImportDirectory(),
+        QDir::cleanPath(selected.path())
+    );
+}
+
+TEST_F(AppConfigTest, RemembersParentDirectoryForSelectedFile)
+{
+    QTemporaryDir selected;
+    ASSERT_TRUE(selected.isValid());
+    const QString file_path = selected.filePath("trace.rocpd");
+    QFile file(file_path);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    file.close();
+
+    AppConfig::getInstance().setLastImportDirectory(file_path);
+
+    EXPECT_EQ(
+        AppConfig::getInstance().getLastImportDirectory(),
+        QDir::cleanPath(selected.path())
+    );
+}
+
+TEST_F(AppConfigTest, IgnoresMissingSelection)
+{
+    QTemporaryDir selected;
+    ASSERT_TRUE(selected.isValid());
+    AppConfig::getInstance().setLastImportDirectory(selected.path());
+
+    AppConfig::getInstance().setLastImportDirectory(selected.filePath("missing"));
+
+    EXPECT_EQ(
+        AppConfig::getInstance().getLastImportDirectory(),
+        QDir::cleanPath(selected.path())
+    );
+}
+
+int main(int argc, char** argv)
+{
+    QTemporaryDir settings_dir;
+    if (!settings_dir.isValid()) return 1;
+
+    QSettings::setDefaultFormat(QSettings::IniFormat);
+    QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, settings_dir.path());
+
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Remember the directory used by the import dialogs so subsequent imports open in
the user's most recently selected location.

Fixes #11.

## Changes

- persist the last import directory through the existing `AppConfig`/`QSettings`
  mechanism
- share the saved location across the Rocprofv3 UI output, ATT, and ROCpd
  import dialogs
- remember a selected file's parent directory
- fall back to the current UI path, Documents, then Home when a saved path is
  unavailable
- add focused tests for fallback, persistence, file-parent, and invalid-path
  behavior

## Validation

- `git diff --check` — passed
- `git show --check` — passed
- compilation, CTest, and clang-format were not run locally because this macOS
  environment does not have CMake, Qt 6 development packages, or
  `clang-format-14`; the PR is opened as a draft for CI validation
