### PR TITLE
Add options for plot view alignment with Compute Unit or Global View

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ compile_commands.json
 # AI and scripts
 *CLAUDE.md
 *__pycache__
+*.codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,47 +2,30 @@
 
 ROCprof Compute Viewer (RCV) is a tool for visualizing and analyzing GPU thread trace data collected with rocprofv3.
 
-## Release 0.2.0
+## Release 0.2.1
 
 ### Added
 
-* Open raw `.att`/`.out` directories (extracted from rocprofiler-sdk thread-trace output) directly, without first converting to JSON (requires a trace-decoder build; see README).
-* Flamegraph view (replaces the Explorer view): per-target-CU/SIMD source/ISA stack rollup, plus a global marker flamegraph when SQTT instrumentation is present.
-* Hidden latency analysis for gfx10+/Navi thread traces, with Total latency and Nonhidden Latency views for instructions, source hotspots and flamegraphs.
-* SQTT instrumentation marker visualization from `.sqtt_funcmap` ELF sections, including marker tracks in Global View.
-* Decoder event and dispatch visualization in Global View for both raw trace-decoder input and JSON input.
-* Event filters in Global View for dispatches, flush events, code-object events, SQTT events, GC rinse events and other decoder events.
-* Heuristic GPU Utilization metric in derived counters. Create a new file to refresh.
-* Shift + Mousewheel to scroll the Compute Unit and Utilization timelines horizontally.
+* SPM JSON counter visualization, including realtime clock alignment and support for derived counters over SPM data.
+* The Wave States plot for eligible single-SE JSON inputs, with per-trace-family defaults under Options → Graph Options.
 * Plot alignment options for keeping timeline plots locked to either the Compute Unit/Utilization detail range or the Global View range.
 
 ### Changed
 
-* LDS, VMEM and Flat utilization are multiplied by 2 relative to previous versions.
-* The Wave States tab shows the precomputed number of active waves in the EXEC, WAIT, and STALL states. It is enabled when the following conditions are met:
-    * Exactly one Shader Engine is enabled.
-    * Loading gfx9/MI300 traces unless overridden under Options → Graph Options
-* Global View event and marker colors have been tuned for readability.
-* Updated the AMD application icon.
-* Updated build documentation, including macOS instructions and trace-decoder build options.
 * Replaced the plot LOD enable/disable setting with a signed LOD bias for finer resolution control.
 * The Options tab now scrolls vertically when the window is too short to show every section.
+* Optimized SQTT marker rendering and updated marker colors.
+* Corrected the notation used for other-SIMD utilization rows.
+* Reorganized and expanded the installation, troubleshooting, hidden-latency and view documentation.
+* Removed the standalone `scripts/generate_snapshot.py` workflow. Raw SDK captures without metadata remain viewable but do not provide ISA/source correlation.
 
 ### Fixed
 
-* Hardcoded target_cu for latency analysis.
-* Incorrect scaling of the clock counter in the wave slot widgets.
-* Global offset handling and wave JSON fallback.
-* Realtime alignment for JSON input and raw `.att` input.
-* Realtime alignment for counters.
-* Global View event rendering performance.
-* Global View misalignment when events or dispatches occur outside the occupancy sample range.
-* Missing user-facing reporting for malformed marker sequences and trace-decoder/input errors.
-* Utilization computation now includes other-SIMD activity where applicable.
 * Graph Options no longer compresses vertically when the window is resized.
+* Plot alignment accounts for the label columns in plots, Compute Unit/Utilization and Global View at every zoom level.
+* Qt 5 builds with the flamegraph view enabled.
+* Trace-decoder record emission and ATT loader coverage.
 
 ### Build and CI
 
-* Added GitHub Actions build, release and CodeQL workflows.
-* Release workflow validation and package verification were improved.
-* Tests now prefer a local GoogleTest installation when available.
+* Added trace-decoder builds and ATT loader tests to CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ ROCprof Compute Viewer (RCV) is a tool for visualizing and analyzing GPU thread 
 * Event filters in Global View for dispatches, flush events, code-object events, SQTT events, GC rinse events and other decoder events.
 * Heuristic GPU Utilization metric in derived counters. Create a new file to refresh.
 * Shift + Mousewheel to scroll the Compute Unit and Utilization timelines horizontally.
+* Plot alignment options for keeping timeline plots locked to either the Compute Unit/Utilization detail range or the Global View range.
 
 ### Changed
 
@@ -24,6 +25,8 @@ ROCprof Compute Viewer (RCV) is a tool for visualizing and analyzing GPU thread 
 * Global View event and marker colors have been tuned for readability.
 * Updated the AMD application icon.
 * Updated build documentation, including macOS instructions and trace-decoder build options.
+* Replaced the plot LOD enable/disable setting with a signed LOD bias for finer resolution control.
+* The Options tab now scrolls vertically when the window is too short to show every section.
 
 ### Fixed
 
@@ -36,6 +39,7 @@ ROCprof Compute Viewer (RCV) is a tool for visualizing and analyzing GPU thread 
 * Global View misalignment when events or dispatches occur outside the occupancy sample range.
 * Missing user-facing reporting for malformed marker sequences and trace-decoder/input errors.
 * Utilization computation now includes other-SIMD activity where applicable.
+* Graph Options no longer compresses vertically when the window is resized.
 
 ### Build and CI
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ For pre-built binaries, see [releases](https://github.com/ROCm/rocprof-compute-v
   - [Instructions View](#instructions-view)
   - [Occupancy and Dispatches Plots](#occupancy-and-dispatches-plots-tab)
   - [Left Side Panel](#left-side-panel)
+  - [Options](#options)
   - [Compute Unit and Utilization Views](#compute-unit-and-utilization-views)
   - [Counters](#counters)
   - [Global View](#global-view)
@@ -119,7 +120,7 @@ If debug symbols are present, rocprofv3 snapshots the related source files, whic
    * Click and drag to select an area.
    * Right click and drag for panning.
    * Clicking on a token in the waveview (Trace) will add a blue marker to identify the cycle of that token.
-* The Highlighted region shows what is visible from the "CU" and "Utilization" tabs.
+* With plot alignment set to **None**, the highlighted region shows what is visible from the Compute Unit and Utilization tabs.
 
 * The Wave States tab shows the precomputed number of active waves in the EXEC, WAIT, and STALL states. It is enabled when the following conditions are met:
     * Exactly one Shader Engine is enabled.
@@ -152,6 +153,16 @@ If debug symbols are present, rocprofv3 snapshots the related source files, whic
     * The iteration is defined as the n-th time that same instruction was executed for each wave (starting at zero).
 * "Search" searches for a specific text on the instruction view. E.g. search for ds_ to find the first lds instruction.
 * "History" contains the history (token+cycle) of previously selected tokens. It can be used to go back to a previous location.
+
+### Options
+
+The Options tab scrolls vertically when the window is too short to display every section. Graph Options includes:
+
+* **LOD bias** controls timeline plot resolution relative to the automatic level. Negative values retain finer detail, positive values use coarser detail, and zero uses the automatic choice.
+* **Plot alignment** controls the horizontal range of all timeline plots:
+  * **None** leaves plot pan and zoom independent and highlights the Compute Unit/Utilization visible range. When alignment is unlocked, the last locked range is retained as the plot's starting range.
+  * **Detail** keeps plots locked to the visible Compute Unit/Utilization range.
+  * **Global** keeps plots locked to the visible Global View range.
 
 ### Compute Unit and Utilization Views
 * Displays the trace aggregated either per-wave (Compute Unit) or per SIMD (Utilization).

--- a/src/config/appconfig.cpp
+++ b/src/config/appconfig.cpp
@@ -33,19 +33,6 @@ AppConfig& AppConfig::getInstance()
 AppConfig::AppConfig() : settings("AMD", "Rocprof-Compute-Viewer") {}
 
 // Graph Options
-PlotAlignment AppConfig::getPlotAlignment() const
-{
-    const int value = settings.value("GraphOptions/PlotAlignment", static_cast<int>(PlotAlignment::None)).toInt();
-    if (value < static_cast<int>(PlotAlignment::None) || value > static_cast<int>(PlotAlignment::Global))
-        return PlotAlignment::None;
-    return static_cast<PlotAlignment>(value);
-}
-
-void AppConfig::setPlotAlignment(PlotAlignment alignment)
-{
-    settings.setValue("GraphOptions/PlotAlignment", static_cast<int>(alignment));
-}
-
 bool AppConfig::getLoadWaveStates() const { return settings.value("GraphOptions/LoadWaveStates", true).toBool(); }
 
 void AppConfig::setLoadWaveStates(bool enabled) { settings.setValue("GraphOptions/LoadWaveStates", enabled); }

--- a/src/config/appconfig.cpp
+++ b/src/config/appconfig.cpp
@@ -33,10 +33,6 @@ AppConfig& AppConfig::getInstance()
 AppConfig::AppConfig() : settings("AMD", "Rocprof-Compute-Viewer") {}
 
 // Graph Options
-int AppConfig::getLevelOfDetailBias() const { return settings.value("GraphOptions/LevelOfDetailBias", 0).toInt(); }
-
-void AppConfig::setLevelOfDetailBias(int bias) { settings.setValue("GraphOptions/LevelOfDetailBias", bias); }
-
 PlotAlignment AppConfig::getPlotAlignment() const
 {
     const int value = settings.value("GraphOptions/PlotAlignment", static_cast<int>(PlotAlignment::None)).toInt();

--- a/src/config/appconfig.cpp
+++ b/src/config/appconfig.cpp
@@ -33,9 +33,22 @@ AppConfig& AppConfig::getInstance()
 AppConfig::AppConfig() : settings("AMD", "Rocprof-Compute-Viewer") {}
 
 // Graph Options
-bool AppConfig::getLevelOfDetail() const { return settings.value("GraphOptions/LevelOfDetail", true).toBool(); }
+int AppConfig::getLevelOfDetailBias() const { return settings.value("GraphOptions/LevelOfDetailBias", 0).toInt(); }
 
-void AppConfig::setLevelOfDetail(bool enabled) { settings.setValue("GraphOptions/LevelOfDetail", enabled); }
+void AppConfig::setLevelOfDetailBias(int bias) { settings.setValue("GraphOptions/LevelOfDetailBias", bias); }
+
+PlotAlignment AppConfig::getPlotAlignment() const
+{
+    const int value = settings.value("GraphOptions/PlotAlignment", static_cast<int>(PlotAlignment::None)).toInt();
+    if (value < static_cast<int>(PlotAlignment::None) || value > static_cast<int>(PlotAlignment::Global))
+        return PlotAlignment::None;
+    return static_cast<PlotAlignment>(value);
+}
+
+void AppConfig::setPlotAlignment(PlotAlignment alignment)
+{
+    settings.setValue("GraphOptions/PlotAlignment", static_cast<int>(alignment));
+}
 
 bool AppConfig::getLoadWaveStates() const { return settings.value("GraphOptions/LoadWaveStates", true).toBool(); }
 

--- a/src/config/appconfig.h
+++ b/src/config/appconfig.h
@@ -40,8 +40,6 @@ public:
     static AppConfig& getInstance();
 
     // Graph Options
-    int getLevelOfDetailBias() const;
-    void setLevelOfDetailBias(int bias);
     PlotAlignment getPlotAlignment() const;
     void setPlotAlignment(PlotAlignment alignment);
     bool getLoadWaveStates() const;

--- a/src/config/appconfig.h
+++ b/src/config/appconfig.h
@@ -27,21 +27,12 @@
 #include <memory>
 #include <string>
 
-enum class PlotAlignment
-{
-    None = 0,
-    Detail = 1,
-    Global = 2
-};
-
 class AppConfig
 {
 public:
     static AppConfig& getInstance();
 
     // Graph Options
-    PlotAlignment getPlotAlignment() const;
-    void setPlotAlignment(PlotAlignment alignment);
     bool getLoadWaveStates() const;
     void setLoadWaveStates(bool enabled);
     bool resolveLoadWaveStatesForTrace(int gfxip, const std::string& gfxv);

--- a/src/config/appconfig.h
+++ b/src/config/appconfig.h
@@ -27,14 +27,23 @@
 #include <memory>
 #include <string>
 
+enum class PlotAlignment
+{
+    None = 0,
+    Detail = 1,
+    Global = 2
+};
+
 class AppConfig
 {
 public:
     static AppConfig& getInstance();
 
     // Graph Options
-    bool getLevelOfDetail() const;
-    void setLevelOfDetail(bool enabled);
+    int getLevelOfDetailBias() const;
+    void setLevelOfDetailBias(int bias);
+    PlotAlignment getPlotAlignment() const;
+    void setPlotAlignment(PlotAlignment alignment);
     bool getLoadWaveStates() const;
     void setLoadWaveStates(bool enabled);
     bool resolveLoadWaveStatesForTrace(int gfxip, const std::string& gfxv);

--- a/src/data/json_emitter.cpp
+++ b/src/data/json_emitter.cpp
@@ -403,8 +403,7 @@ void JsonRecordEmitter::emitWaveStates()
             auto& samples = store.wave_state_series[state];
             const size_t size = std::min(time.size(), values.size());
             samples.reserve(size);
-            for (size_t i = 0; i < size; i++)
-                samples.push_back({time.at(i).get<float>(), values.at(i).get<float>()});
+            for (size_t i = 0; i < size; i++) samples.push_back({time.at(i).get<float>(), values.at(i).get<float>()});
 
             if (samples.size() < 2) store.wave_state_series.erase(state);
         }

--- a/src/graphics/plot.cpp
+++ b/src/graphics/plot.cpp
@@ -22,6 +22,7 @@
 
 #include "plot.h"
 #include <QWheelEvent>
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include "config/config.hpp"
@@ -143,9 +144,9 @@ bool PlotCurve::CreateLODs(int mip, std::vector<WeightedPoint>& points)
     return true;
 }
 
-void PlotCurve::UpdateLOD(float range, int width, bool bAuto)
+void PlotCurve::UpdateLOD(float range, int width, int bias)
 {
-    if (!bAuto || lods.size() < 2)
+    if (lods.size() < 2)
     {
         lod = 0;
         return;
@@ -157,7 +158,7 @@ void PlotCurve::UpdateLOD(float range, int width, bool bAuto)
 
     while (lod < lods.size() && lods.at(lod).min_interval < point_density_ratio) lod++;
 
-    lod--;
+    lod = std::clamp(lod - 1 + bias, 0, static_cast<int>(lods.size()) - 1);
 }
 
 PlotGraph::PlotGraph(int _penwidth, QWidget* parent) : BasePlotWidget(parent), penwidth(_penwidth)
@@ -174,6 +175,7 @@ void PlotGraph::wheelEvent(QWheelEvent* ev)
     double scale = pow(1.001, ev->angleDelta().y());
 
     if (ev->modifiers() & Qt::ControlModifier) { yscale *= scale; }
+    else if (applyAlignedRange()) { return; }
     else
     {
         double midpoint = pixelToPos(mousepos.x());
@@ -190,19 +192,24 @@ void PlotGraph::mousePressEvent(QMouseEvent* ev)
 
     if (ev->button() == Qt::LeftButton)
     {
+        const bool range_aligned = applyAlignedRange();
         if (ev->modifiers() & Qt::ControlModifier)
         {
-            xscale = 1;
             yscale = 1;
-            xoffset = 1;
+            if (!range_aligned)
+            {
+                xscale = 1;
+                xoffset = 1;
+            }
         }
+        else if (range_aligned) { return; }
         else
         {
             bLClick = true;
             lclickpos = ev->pos();
         }
     }
-    else if (ev->button() == Qt::RightButton)
+    else if (ev->button() == Qt::RightButton && !applyAlignedRange())
         setCursor(Qt::ClosedHandCursor);
 
     update();
@@ -229,6 +236,7 @@ void PlotGraph::mouseReleaseEvent(QMouseEvent* ev)
 void PlotGraph::paintEvent(QPaintEvent* ev)
 {
     QWidget::paintEvent(ev);
+    const bool range_aligned = applyAlignedRange();
     const QColor bkgcolor = WindowColors::GraphBkg();
 
     QPainter painter(this);
@@ -239,16 +247,19 @@ void PlotGraph::paintEvent(QPaintEvent* ev)
 
     painter.fillRect(QRect(left_space, 0, width() - left_space, height()), bkgcolor);
 
-    if (auto view = MainWindow::getCUScroll())
+    if (!range_aligned)
     {
-        Color viewcolor = bkgcolor;
-        viewcolor += Color(14, 18, 24);
+        if (auto view = MainWindow::getCUScroll())
+        {
+            Color viewcolor = bkgcolor;
+            viewcolor += Color(14, 18, 24);
 
-        int pos_start = posToPixel(QCustomScroll::clock_cutoff_start + view->start);
-        int pos_end = posToPixel(QCustomScroll::clock_cutoff_start + view->start + view->range);
+            int pos_start = posToPixel(QCustomScroll::clock_cutoff_start + view->start);
+            int pos_end = posToPixel(QCustomScroll::clock_cutoff_start + view->start + view->range);
 
-        if (pos_start < width() && pos_end > 0)
-            painter.fillRect(QRect(pos_start, 0, pos_end - pos_start, height()), viewcolor);
+            if (pos_start < width() && pos_end > 0)
+                painter.fillRect(QRect(pos_start, 0, pos_end - pos_start, height()), viewcolor);
+        }
     }
 
     QFont font = MainWindow::default_font.isEmpty() ? painter.font() : QFont(MainWindow::default_font);
@@ -269,7 +280,7 @@ void PlotGraph::paintEvent(QPaintEvent* ev)
     {
         if (!series.lods.size() || series.disabled) continue;
 
-        series.UpdateLOD((xmax - xmin) / xscale, width(), bAutoLod);
+        series.UpdateLOD((xmax - xmin) / xscale, width(), lodBias);
         auto& data = series.get().data;
         if (data.size() < 2) continue;
 
@@ -429,7 +440,7 @@ void PlotGraph::mouseMoveEvent(QMouseEvent* event)
 {
     BasePlotWidget::mouseMoveEvent(event);
 
-    if (event->buttons() & Qt::RightButton)
+    if ((event->buttons() & Qt::RightButton) && !applyAlignedRange())
     {
         double cvt = xmax / scaledwidth();
         xoffset += cvt * (event->pos().x() - mousepos.x());
@@ -443,4 +454,14 @@ void PlotGraph::mouseMoveEvent(QMouseEvent* event)
 
     UpdateGraphTable(pixelToPos(mousepos.x()));
     update();
+}
+
+bool PlotGraph::applyAlignedRange()
+{
+    const auto range = MainWindow::getAlignedPlotRange();
+    if (!range || range->end <= range->start || xmax <= 0) return false;
+
+    xoffset = -range->start;
+    xscale = xmax / (range->end - range->start);
+    return true;
 }

--- a/src/graphics/plot.cpp
+++ b/src/graphics/plot.cpp
@@ -249,13 +249,13 @@ void PlotGraph::paintEvent(QPaintEvent* ev)
 
     if (!range_aligned)
     {
-        if (auto view = MainWindow::getCUScroll())
+        if (const auto reference = MainWindow::getCUPlotAlignmentReference())
         {
             Color viewcolor = bkgcolor;
             viewcolor += Color(14, 18, 24);
 
-            int pos_start = posToPixel(QCustomScroll::clock_cutoff_start + view->start);
-            int pos_end = posToPixel(QCustomScroll::clock_cutoff_start + view->start + view->range);
+            int pos_start = posToPixel(reference->clock_at_left);
+            int pos_end = posToPixel(reference->clock_at_left + reference->pixel_width * reference->clocks_per_pixel);
 
             if (pos_start < width() && pos_end > 0)
                 painter.fillRect(QRect(pos_start, 0, pos_end - pos_start, height()), viewcolor);
@@ -458,10 +458,14 @@ void PlotGraph::mouseMoveEvent(QMouseEvent* event)
 
 bool PlotGraph::applyAlignedRange()
 {
-    const auto range = MainWindow::getAlignedPlotRange();
-    if (!range || range->end <= range->start || xmax <= 0) return false;
+    const auto reference = MainWindow::getPlotAlignmentReference();
+    if (!reference || reference->clocks_per_pixel <= 0 || xmax <= 0) return false;
 
-    xoffset = -range->start;
-    xscale = xmax / (range->end - range->start);
+    const int plot_global_left = mapToGlobal(QPoint(left_space, 0)).x();
+    const auto range = alignedPlotRange(*reference, plot_global_left, smallwidth());
+    if (range.end <= range.start) return false;
+
+    xoffset = -range.start;
+    xscale = xmax / (range.end - range.start);
     return true;
 }

--- a/src/graphics/plot.h
+++ b/src/graphics/plot.h
@@ -70,7 +70,7 @@ struct PlotCurve
     const LODCurve& get() const { return lods.at(lod); }
     void SetData(std::vector<WeightedPoint>&& data);
     bool CreateLODs(int mip, std::vector<WeightedPoint>& points);
-    void UpdateLOD(float range, int width, bool bAuto);
+    void UpdateLOD(float range, int width, int bias);
 };
 
 class PlotGraph : public BasePlotWidget
@@ -93,11 +93,12 @@ public:
         update();
     };
 
-    void setAutoLod(bool bAutoLod)
+    void setLodBias(int bias)
     {
-        this->bAutoLod = bAutoLod;
+        lodBias = bias;
         update();
     };
+    void syncAlignedRange() { applyAlignedRange(); }
 
     void setDisabled(const std::string& name, bool disable)
     {
@@ -127,7 +128,8 @@ private slots:
 protected:
     void paintEvent(QPaintEvent*) override;
     virtual void UpdateGraphTable(float timepos) = 0;
-    bool bAutoLod = true;
+    bool applyAlignedRange();
+    int lodBias = 0;
 
     double xmin = 0;
     double xmax = 1;

--- a/src/graphics/plot_alignment.h
+++ b/src/graphics/plot_alignment.h
@@ -22,6 +22,13 @@
 
 #pragma once
 
+enum class PlotAlignment
+{
+    None,
+    Detail,
+    Global
+};
+
 struct PlotAlignmentReference
 {
     double clock_at_left;

--- a/src/graphics/plot_alignment.h
+++ b/src/graphics/plot_alignment.h
@@ -1,0 +1,46 @@
+// MIT License
+//
+// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+struct PlotAlignmentReference
+{
+    double clock_at_left;
+    double clocks_per_pixel;
+    int global_left;
+    int pixel_width;
+};
+
+struct PlotViewRange
+{
+    double start;
+    double end;
+};
+
+inline PlotViewRange alignedPlotRange(
+    const PlotAlignmentReference& reference, int plot_global_left, int plot_pixel_width
+)
+{
+    const double start =
+        reference.clock_at_left + (plot_global_left - reference.global_left) * reference.clocks_per_pixel;
+    return {start, start + plot_pixel_width * reference.clocks_per_pixel};
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1148,9 +1148,8 @@ MainWindow::LoadResult MainWindow::LoadInputImpl(InputInfo input_info, const std
                     *data_store,
                     [this](const DataStore& trace)
                     {
-                        const bool enabled = AppConfig::getInstance().resolveLoadWaveStatesForTrace(
-                            trace.gfxip, trace.gfxv
-                        );
+                        const bool enabled =
+                            AppConfig::getInstance().resolveLoadWaveStatesForTrace(trace.gfxip, trace.gfxv);
                         const QSignalBlocker blocker(ui->load_wave_states_box);
                         ui->load_wave_states_box->setChecked(enabled);
                         return enabled;
@@ -2077,16 +2076,10 @@ void MainWindow::CreateGlobalView()
     // Connect scroll bars to sticky elements
     global_view_widget->setScrollArea(global_view_scrollarea);
     connect(
-        global_view_scrollarea->horizontalScrollBar(),
-        &QScrollBar::valueChanged,
-        this,
-        &MainWindow::updateAlignedPlots
+        global_view_scrollarea->horizontalScrollBar(), &QScrollBar::valueChanged, this, &MainWindow::updateAlignedPlots
     );
     connect(
-        global_view_scrollarea->horizontalScrollBar(),
-        &QScrollBar::rangeChanged,
-        this,
-        &MainWindow::updateAlignedPlots
+        global_view_scrollarea->horizontalScrollBar(), &QScrollBar::rangeChanged, this, &MainWindow::updateAlignedPlots
     );
 
     // Populate the label panel with data from the global view
@@ -2492,17 +2485,19 @@ void MainWindow::setupConfigConnections()
 {
     // Graph Options
     connect(
-        ui->lod_bias_spinBox,
-        qOverload<int>(&QSpinBox::valueChanged),
-        this,
-        &MainWindow::saveLevelOfDetailBiasSetting
+        ui->lod_bias_spinBox, qOverload<int>(&QSpinBox::valueChanged), this, &MainWindow::saveLevelOfDetailBiasSetting
     );
     const auto connect_alignment = [this](QRadioButton* button, PlotAlignment alignment)
     {
-        connect(button, &QRadioButton::toggled, this, [this, alignment](bool checked)
-        {
-            if (checked) savePlotAlignmentSetting(alignment);
-        });
+        connect(
+            button,
+            &QRadioButton::toggled,
+            this,
+            [this, alignment](bool checked)
+            {
+                if (checked) savePlotAlignmentSetting(alignment);
+            }
+        );
     };
     connect_alignment(ui->plot_alignment_none, PlotAlignment::None);
     connect_alignment(ui->plot_alignment_detail, PlotAlignment::Detail);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1808,24 +1808,35 @@ std::shared_ptr<class ScrollValue> MainWindow::getCUScroll()
     return nullptr;
 }
 
-std::optional<MainWindow::PlotViewRange> MainWindow::getAlignedPlotRange()
+std::optional<PlotAlignmentReference> MainWindow::getCUPlotAlignmentReference()
+{
+    auto* window = MainWindow::window;
+    if (!window || !window->cuwaves_content || !window->cuwaves_content->cuwaves_content) return std::nullopt;
+
+    const auto view = getCUScroll();
+    auto* timeline = window->cuwaves_content->cuwaves_content;
+    const int pixel_width = timeline->width();
+    if (!view || pixel_width <= 0) return std::nullopt;
+
+    const double start = QCustomScroll::clock_cutoff_start + view->start.load();
+    const double clocks_per_pixel = static_cast<double>(Token::PosToClock(pixel_width)) / pixel_width;
+    const int global_left = timeline->mapToGlobal(QPoint(0, 0)).x();
+    return PlotAlignmentReference{start, clocks_per_pixel, global_left, pixel_width};
+}
+
+std::optional<PlotAlignmentReference> MainWindow::getPlotAlignmentReference()
 {
     auto* window = MainWindow::window;
     if (!window || window->plot_alignment == PlotAlignment::None) return std::nullopt;
 
-    if (window->plot_alignment == PlotAlignment::Detail)
-    {
-        const auto view = getCUScroll();
-        if (!view) return std::nullopt;
-        const double start = QCustomScroll::clock_cutoff_start + view->start.load();
-        return PlotViewRange{start, start + view->range.load()};
-    }
+    if (window->plot_alignment == PlotAlignment::Detail) return getCUPlotAlignmentReference();
 
     if (!window->global_view_widget || !window->global_view_scrollarea) return std::nullopt;
+    auto* viewport = window->global_view_scrollarea->viewport();
     const auto* scrollbar = window->global_view_scrollarea->horizontalScrollBar();
     const double start = QGlobalView::PosToClock(scrollbar->value());
-    const double range = window->global_view_scrollarea->viewport()->width() * QGlobalView::Delta();
-    return PlotViewRange{start, start + range};
+    return PlotAlignmentReference{
+        start, static_cast<double>(QGlobalView::Delta()), viewport->mapToGlobal(QPoint(0, 0)).x(), viewport->width()};
 }
 
 void MainWindow::setPlotBarPos(float x)
@@ -2440,7 +2451,6 @@ void MainWindow::loadConfigSettings()
     AppConfig& config = AppConfig::getInstance();
 
     // Graph Options
-    ui->lod_bias_spinBox->setValue(config.getLevelOfDetailBias());
     plot_alignment = config.getPlotAlignment();
     ui->plot_alignment_none->setChecked(plot_alignment == PlotAlignment::None);
     ui->plot_alignment_detail->setChecked(plot_alignment == PlotAlignment::Detail);
@@ -2484,9 +2494,7 @@ void MainWindow::loadConfigSettings()
 void MainWindow::setupConfigConnections()
 {
     // Graph Options
-    connect(
-        ui->lod_bias_spinBox, qOverload<int>(&QSpinBox::valueChanged), this, &MainWindow::saveLevelOfDetailBiasSetting
-    );
+    connect(ui->lod_bias_spinBox, qOverload<int>(&QSpinBox::valueChanged), this, &MainWindow::UpdateGraphLodBias);
     const auto connect_alignment = [this](QRadioButton* button, PlotAlignment alignment)
     {
         connect(
@@ -2540,12 +2548,6 @@ void MainWindow::setupConfigConnections()
     connectColumnCheckbox(ui->col_codeobj_box, ASMCodeline::Element::ECODEOBJ);
     connectColumnCheckbox(ui->col_vaddr_box, ASMCodeline::Element::EADDRESS);
     connectColumnCheckbox(ui->col_sourceref_box, ASMCodeline::Element::ESOURCEREF);
-}
-
-void MainWindow::saveLevelOfDetailBiasSetting(int bias)
-{
-    AppConfig::getInstance().setLevelOfDetailBias(bias);
-    UpdateGraphLodBias(bias);
 }
 
 void MainWindow::savePlotAlignmentSetting(PlotAlignment alignment)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1819,9 +1819,8 @@ std::optional<PlotAlignmentReference> MainWindow::getCUPlotAlignmentReference()
     if (!view || pixel_width <= 0) return std::nullopt;
 
     const double start = QCustomScroll::clock_cutoff_start + view->start.load();
-    const double clocks_per_pixel = static_cast<double>(Token::PosToClock(pixel_width)) / pixel_width;
     const int global_left = timeline->mapToGlobal(QPoint(0, 0)).x();
-    return PlotAlignmentReference{start, clocks_per_pixel, global_left, pixel_width};
+    return PlotAlignmentReference{start, Token::ClocksPerPixel(), global_left, pixel_width};
 }
 
 std::optional<PlotAlignmentReference> MainWindow::getPlotAlignmentReference()
@@ -2451,10 +2450,6 @@ void MainWindow::loadConfigSettings()
     AppConfig& config = AppConfig::getInstance();
 
     // Graph Options
-    plot_alignment = config.getPlotAlignment();
-    ui->plot_alignment_none->setChecked(plot_alignment == PlotAlignment::None);
-    ui->plot_alignment_detail->setChecked(plot_alignment == PlotAlignment::Detail);
-    ui->plot_alignment_global->setChecked(plot_alignment == PlotAlignment::Global);
     ui->load_wave_states_box->setChecked(config.getLoadWaveStates());
 
     // Source Options
@@ -2503,7 +2498,7 @@ void MainWindow::setupConfigConnections()
             this,
             [this, alignment](bool checked)
             {
-                if (checked) savePlotAlignmentSetting(alignment);
+                if (checked) setPlotAlignment(alignment);
             }
         );
     };
@@ -2550,7 +2545,7 @@ void MainWindow::setupConfigConnections()
     connectColumnCheckbox(ui->col_sourceref_box, ASMCodeline::Element::ESOURCEREF);
 }
 
-void MainWindow::savePlotAlignmentSetting(PlotAlignment alignment)
+void MainWindow::setPlotAlignment(PlotAlignment alignment)
 {
     if (alignment == PlotAlignment::None && plot_alignment != PlotAlignment::None)
     {
@@ -2560,7 +2555,6 @@ void MainWindow::savePlotAlignmentSetting(PlotAlignment alignment)
         if (dispatch_plot) dispatch_plot->syncAlignedRange();
     }
     plot_alignment = alignment;
-    AppConfig::getInstance().setPlotAlignment(alignment);
     updateAlignedPlots();
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -321,7 +321,6 @@ MainWindow::MainWindow(std::string uidir) : QMainWindow(nullptr), ui(new Ui::Mai
         ResetSelector();
     }
 
-    connect(ui->lod_bias_spinBox, qOverload<int>(&QSpinBox::valueChanged), this, &MainWindow::UpdateGraphLodBias);
     connect(cuwaves_h_scrollarea, &QCustomScroll::valueupdated, this, &MainWindow::updateAlignedPlots);
 
     connect(ui->actionJsons_folder, &QAction::triggered, this, &MainWindow::SetJsonsFolder);
@@ -2548,7 +2547,11 @@ void MainWindow::setupConfigConnections()
     connectColumnCheckbox(ui->col_sourceref_box, ASMCodeline::Element::ESOURCEREF);
 }
 
-void MainWindow::saveLevelOfDetailBiasSetting(int bias) { AppConfig::getInstance().setLevelOfDetailBias(bias); }
+void MainWindow::saveLevelOfDetailBiasSetting(int bias)
+{
+    AppConfig::getInstance().setLevelOfDetailBias(bias);
+    UpdateGraphLodBias(bias);
+}
 
 void MainWindow::savePlotAlignmentSetting(PlotAlignment alignment)
 {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -321,7 +321,8 @@ MainWindow::MainWindow(std::string uidir) : QMainWindow(nullptr), ui(new Ui::Mai
         ResetSelector();
     }
 
-    connect(ui->lod_checkBox, &QCheckBox::stateChanged, this, &MainWindow::UpdateGraphAutoLod);
+    connect(ui->lod_bias_spinBox, qOverload<int>(&QSpinBox::valueChanged), this, &MainWindow::UpdateGraphLodBias);
+    connect(cuwaves_h_scrollarea, &QCustomScroll::valueupdated, this, &MainWindow::updateAlignedPlots);
 
     connect(ui->actionJsons_folder, &QAction::triggered, this, &MainWindow::SetJsonsFolder);
     connect(ui->actionAttFiles, &QAction::triggered, this, &MainWindow::OpenAttFiles);
@@ -1616,7 +1617,7 @@ void MainWindow::CreateCountersPlot()
     // active, or support counter-source-specific definition files.
     std::string derived_definitions = DerivedCounterEditor::loadDefinitions();
 
-    this->counters_plot->setAutoLod(ui->lod_checkBox->isChecked());
+    this->counters_plot->setLodBias(ui->lod_bias_spinBox->value());
     this->counters_plot->setGeometry(0, 0, 300, this->counters_plot->size().width());
     this->counters_plot->UpdateDataSelection(perfcounter_names, derived_definitions);
     UpdateCountersPlotSelection();
@@ -1734,7 +1735,7 @@ void MainWindow::CreateWavesPlot()
     waves_plot = new WavePlotView(this);
     waves_plot->setGeometry(0, 0, 300, waves_plot->size().width());
     waves_plot->LoadWaveStateData(*data_store);
-    waves_plot->setAutoLod(ui->lod_checkBox->isChecked());
+    waves_plot->setLodBias(ui->lod_bias_spinBox->value());
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     accordion->replaceContentByTitle("Wave States", waves_plot);
@@ -1798,7 +1799,7 @@ void MainWindow::CreateOccupancyPlot(bool bDispatch)
             dynamic_cast<OccupancyPlotView*>(plot)->LoadOccupancyData(*data_store);
     }
     else { plot->LoadOccupancyData(GetUIDir() + "occupancy.json"); }
-    plot->setAutoLod(ui->lod_checkBox->isChecked());
+    plot->setLodBias(ui->lod_bias_spinBox->value());
 }
 
 std::shared_ptr<class ScrollValue> MainWindow::getCUScroll()
@@ -1807,6 +1808,26 @@ std::shared_ptr<class ScrollValue> MainWindow::getCUScroll()
         if (auto* waveview = window->cuwaves_h_scrollarea)
             if (auto view = waveview->view) return view;
     return nullptr;
+}
+
+std::optional<MainWindow::PlotViewRange> MainWindow::getAlignedPlotRange()
+{
+    auto* window = MainWindow::window;
+    if (!window || window->plot_alignment == PlotAlignment::None) return std::nullopt;
+
+    if (window->plot_alignment == PlotAlignment::Detail)
+    {
+        const auto view = getCUScroll();
+        if (!view) return std::nullopt;
+        const double start = QCustomScroll::clock_cutoff_start + view->start.load();
+        return PlotViewRange{start, start + view->range.load()};
+    }
+
+    if (!window->global_view_widget || !window->global_view_scrollarea) return std::nullopt;
+    const auto* scrollbar = window->global_view_scrollarea->horizontalScrollBar();
+    const double start = QGlobalView::PosToClock(scrollbar->value());
+    const double range = window->global_view_scrollarea->viewport()->width() * QGlobalView::Delta();
+    return PlotViewRange{start, start + range};
 }
 
 void MainWindow::setPlotBarPos(float x)
@@ -1865,12 +1886,20 @@ void MainWindow::UpdateOccupancyInfo(const std::vector<std::pair<std::string, in
     }
 }
 
-void MainWindow::UpdateGraphAutoLod(int bAutoLod)
+void MainWindow::UpdateGraphLodBias(int bias)
 {
-    if (waves_plot) waves_plot->setAutoLod((bool) bAutoLod);
-    if (counters_plot) counters_plot->setAutoLod((bool) bAutoLod);
-    if (occupancy_plot) occupancy_plot->setAutoLod((bool) bAutoLod);
-    if (dispatch_plot) dispatch_plot->setAutoLod((bool) bAutoLod);
+    if (waves_plot) waves_plot->setLodBias(bias);
+    if (counters_plot) counters_plot->setLodBias(bias);
+    if (occupancy_plot) occupancy_plot->setLodBias(bias);
+    if (dispatch_plot) dispatch_plot->setLodBias(bias);
+}
+
+void MainWindow::updateAlignedPlots()
+{
+    if (waves_plot) waves_plot->update();
+    if (counters_plot) counters_plot->update();
+    if (occupancy_plot) occupancy_plot->update();
+    if (dispatch_plot) dispatch_plot->update();
 }
 
 void MainWindow::incrementWaveViewMipmap(int inc, float position)
@@ -1929,6 +1958,7 @@ void MainWindow::incrementGlobalViewMipmap(int inc, int content_mouse_x)
     if (new_mip < old_mip && new_scroll > scrollbar->maximum()) scrollbar->setMaximum(new_scroll);
     scrollbar->setValue(new_scroll);
     window->global_view_widget->SetMip(new_mip);
+    window->updateAlignedPlots();
 
     // Set scroll again after layout update for zoom out
     if (new_mip > old_mip) scrollbar->setValue(new_scroll);
@@ -1946,6 +1976,7 @@ void MainWindow::SetGlobalViewMipmap(int spinValue)
     int new_scroll = QGlobalView::calcZoomScroll(old_mip, new_mip, old_scroll, viewport_center);
 
     if (global_view_widget) global_view_widget->SetMip(new_mip);
+    updateAlignedPlots();
 
     // Use timer to set scroll after layout updates
     slider_global = new_scroll;
@@ -2046,6 +2077,18 @@ void MainWindow::CreateGlobalView()
 
     // Connect scroll bars to sticky elements
     global_view_widget->setScrollArea(global_view_scrollarea);
+    connect(
+        global_view_scrollarea->horizontalScrollBar(),
+        &QScrollBar::valueChanged,
+        this,
+        &MainWindow::updateAlignedPlots
+    );
+    connect(
+        global_view_scrollarea->horizontalScrollBar(),
+        &QScrollBar::rangeChanged,
+        this,
+        &MainWindow::updateAlignedPlots
+    );
 
     // Populate the label panel with data from the global view
     global_view_widget->populateLabelPanel();
@@ -2055,6 +2098,7 @@ void MainWindow::CreateGlobalView()
     mainLayout->addWidget(contentWidget);
 
     this->global_view_tab->setLayout(mainLayout);
+    updateAlignedPlots();
 }
 
 void MainWindow::AddHistoryEntry(int64_t cycle, std::string_view type, std::string_view asmline)
@@ -2404,7 +2448,11 @@ void MainWindow::loadConfigSettings()
     AppConfig& config = AppConfig::getInstance();
 
     // Graph Options
-    ui->lod_checkBox->setChecked(config.getLevelOfDetail());
+    ui->lod_bias_spinBox->setValue(config.getLevelOfDetailBias());
+    plot_alignment = config.getPlotAlignment();
+    ui->plot_alignment_none->setChecked(plot_alignment == PlotAlignment::None);
+    ui->plot_alignment_detail->setChecked(plot_alignment == PlotAlignment::Detail);
+    ui->plot_alignment_global->setChecked(plot_alignment == PlotAlignment::Global);
     ui->load_wave_states_box->setChecked(config.getLoadWaveStates());
 
     // Source Options
@@ -2444,7 +2492,22 @@ void MainWindow::loadConfigSettings()
 void MainWindow::setupConfigConnections()
 {
     // Graph Options
-    connect(ui->lod_checkBox, &QCheckBox::stateChanged, this, &MainWindow::saveLevelOfDetailSetting);
+    connect(
+        ui->lod_bias_spinBox,
+        qOverload<int>(&QSpinBox::valueChanged),
+        this,
+        &MainWindow::saveLevelOfDetailBiasSetting
+    );
+    const auto connect_alignment = [this](QRadioButton* button, PlotAlignment alignment)
+    {
+        connect(button, &QRadioButton::toggled, this, [this, alignment](bool checked)
+        {
+            if (checked) savePlotAlignmentSetting(alignment);
+        });
+    };
+    connect_alignment(ui->plot_alignment_none, PlotAlignment::None);
+    connect_alignment(ui->plot_alignment_detail, PlotAlignment::Detail);
+    connect_alignment(ui->plot_alignment_global, PlotAlignment::Global);
     connect(ui->load_wave_states_box, &QCheckBox::stateChanged, this, &MainWindow::saveLoadWaveStatesSetting);
 
     // Source Options
@@ -2485,7 +2548,21 @@ void MainWindow::setupConfigConnections()
     connectColumnCheckbox(ui->col_sourceref_box, ASMCodeline::Element::ESOURCEREF);
 }
 
-void MainWindow::saveLevelOfDetailSetting(int state) { AppConfig::getInstance().setLevelOfDetail(state != 0); }
+void MainWindow::saveLevelOfDetailBiasSetting(int bias) { AppConfig::getInstance().setLevelOfDetailBias(bias); }
+
+void MainWindow::savePlotAlignmentSetting(PlotAlignment alignment)
+{
+    if (alignment == PlotAlignment::None && plot_alignment != PlotAlignment::None)
+    {
+        if (waves_plot) waves_plot->syncAlignedRange();
+        if (counters_plot) counters_plot->syncAlignedRange();
+        if (occupancy_plot) occupancy_plot->syncAlignedRange();
+        if (dispatch_plot) dispatch_plot->syncAlignedRange();
+    }
+    plot_alignment = alignment;
+    AppConfig::getInstance().setPlotAlignment(alignment);
+    updateAlignedPlots();
+}
 
 void MainWindow::saveLoadWaveStatesSetting(int state)
 {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -38,7 +38,6 @@
 #include <string_view>
 #include <unordered_set>
 #include <vector>
-#include "config/appconfig.h"
 #include "graphics/hotspot_view.h"
 #include "graphics/plot_alignment.h"
 #include "util/custom_layouts.h"
@@ -246,7 +245,7 @@ private:
     void updateAlignedPlots();
 
     // Config save slots
-    void savePlotAlignmentSetting(PlotAlignment alignment);
+    void setPlotAlignment(PlotAlignment alignment);
     void saveLoadWaveStatesSetting(int state);
     void saveDisplayLineNumberSetting(int state);
     void saveSourceHotspotSizeSetting();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -38,6 +38,7 @@
 #include <string_view>
 #include <unordered_set>
 #include <vector>
+#include "config/appconfig.h"
 #include "graphics/hotspot_view.h"
 #include "util/custom_layouts.h"
 #include "util/diagnostic_log.h"
@@ -73,6 +74,12 @@ public:
         QString message;
     };
 
+    struct PlotViewRange
+    {
+        double start;
+        double end;
+    };
+
     MainWindow(std::string uidir);
     virtual ~MainWindow();
     virtual void paintEvent(QPaintEvent* event) override;
@@ -87,7 +94,7 @@ public:
     void CreateWavesPlot();
     void setPlotBarPos(float x);
     void UpdateGraphInfo(const std::string& name, float value);
-    void UpdateGraphAutoLod(int bAutoLod);
+    void UpdateGraphLodBias(int bias);
     void ToggleDisplayLineNumber(int display);
     void SetJsonsFolder();
     void OpenSpmJson();
@@ -174,6 +181,7 @@ public:
     static void incrementWaveViewMipmap(int value, float position);
     static void incrementGlobalViewMipmap(int inc, int content_mouse_x);
     static std::shared_ptr<class ScrollValue> getCUScroll();
+    static std::optional<PlotViewRange> getAlignedPlotRange();
 
     static int& font();
     void updateFont();
@@ -231,6 +239,7 @@ private:
 
     int64_t current_loaded_clk_start = 0;
     int64_t current_loaded_clk_end = 0;
+    PlotAlignment plot_alignment = PlotAlignment::None;
 
     class FlameGraphWidget* flameGraph = nullptr;
     class MarkerFlameGraphWidget* markerFlameGraph = nullptr;
@@ -238,9 +247,11 @@ private:
 
     void loadConfigSettings();
     void setupConfigConnections();
+    void updateAlignedPlots();
 
     // Config save slots
-    void saveLevelOfDetailSetting(int state);
+    void saveLevelOfDetailBiasSetting(int bias);
+    void savePlotAlignmentSetting(PlotAlignment alignment);
     void saveLoadWaveStatesSetting(int state);
     void saveDisplayLineNumberSetting(int state);
     void saveSourceHotspotSizeSetting();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -40,6 +40,7 @@
 #include <vector>
 #include "config/appconfig.h"
 #include "graphics/hotspot_view.h"
+#include "graphics/plot_alignment.h"
 #include "util/custom_layouts.h"
 #include "util/diagnostic_log.h"
 
@@ -72,12 +73,6 @@ public:
     {
         LoadStatus status = LoadStatus::Success;
         QString message;
-    };
-
-    struct PlotViewRange
-    {
-        double start;
-        double end;
     };
 
     MainWindow(std::string uidir);
@@ -181,7 +176,8 @@ public:
     static void incrementWaveViewMipmap(int value, float position);
     static void incrementGlobalViewMipmap(int inc, int content_mouse_x);
     static std::shared_ptr<class ScrollValue> getCUScroll();
-    static std::optional<PlotViewRange> getAlignedPlotRange();
+    static std::optional<PlotAlignmentReference> getCUPlotAlignmentReference();
+    static std::optional<PlotAlignmentReference> getPlotAlignmentReference();
 
     static int& font();
     void updateFont();
@@ -250,7 +246,6 @@ private:
     void updateAlignedPlots();
 
     // Config save slots
-    void saveLevelOfDetailBiasSetting(int bias);
     void savePlotAlignmentSetting(PlotAlignment alignment);
     void saveLoadWaveStatesSetting(int state);
     void saveDisplayLineNumberSetting(int state);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -573,7 +573,26 @@
         </attribute>
         <layout class="QVBoxLayout" name="verticalLayout_13">
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_12">
+          <widget class="QScrollArea" name="options_scroll_area">
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="horizontalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
+           </property>
+           <property name="widgetResizable">
+            <bool>true</bool>
+           </property>
+           <widget class="QWidget" name="options_scroll_contents">
+            <property name="geometry">
+             <rect>
+              <x>0</x>
+              <y>0</y>
+              <width>100</width>
+              <height>100</height>
+             </rect>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_12">
            <item>
             <widget class="QFrame" name="frame_3">
              <property name="frameShape">
@@ -598,8 +617,17 @@
               <property name="bottomMargin">
                <number>0</number>
               </property>
+              <property name="sizeConstraint">
+               <enum>QLayout::SetMinimumSize</enum>
+              </property>
               <item>
                <widget class="QFrame" name="frame_5">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="minimumSize">
                  <size>
                   <width>0</width>
@@ -643,19 +671,66 @@
                    <property name="alignment">
                     <set>Qt::AlignCenter</set>
                    </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="lod_checkBox">
-                   <property name="text">
-                    <string>Level of detail</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
+                 </widget>
+                </item>
+                <item>
+                 <layout class="QHBoxLayout" name="lod_bias_layout">
+                  <item>
+                   <widget class="QLabel" name="lod_bias_label">
+                    <property name="text">
+                     <string>LOD bias</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QSpinBox" name="lod_bias_spinBox">
+                    <property name="toolTip">
+                     <string>Negative values draw finer plot detail; positive values draw coarser detail.</string>
+                    </property>
+                    <property name="minimum">
+                     <number>-20</number>
+                    </property>
+                    <property name="maximum">
+                     <number>20</number>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="plot_alignment_group">
+                  <property name="title">
+                   <string>Plot alignment</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="plot_alignment_layout">
+                   <item>
+                    <widget class="QRadioButton" name="plot_alignment_none">
+                     <property name="text">
+                      <string>None</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QRadioButton" name="plot_alignment_detail">
+                     <property name="text">
+                      <string>Detail</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QRadioButton" name="plot_alignment_global">
+                     <property name="text">
+                      <string>Global</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
                   <widget class="QCheckBox" name="load_wave_states_box">
                    <property name="toolTip">
                     <string>Loads wstates*.json and enables the Wave States tab for eligible single-SE JSON inputs.</string>
@@ -972,7 +1047,9 @@
              </layout>
             </widget>
            </item>
-          </layout>
+            </layout>
+           </widget>
+          </widget>
          </item>
         </layout>
        </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -628,12 +628,6 @@
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>0</width>
-                  <height>64</height>
-                 </size>
-                </property>
                 <property name="frameShape">
                  <enum>QFrame::StyledPanel</enum>
                 </property>
@@ -641,6 +635,9 @@
                  <enum>QFrame::Raised</enum>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_16">
+                 <property name="sizeConstraint">
+                  <enum>QLayout::SetMinimumSize</enum>
+                 </property>
                  <property name="spacing">
                   <number>5</number>
                  </property>

--- a/src/util/accordionwidget.h
+++ b/src/util/accordionwidget.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <QMouseEvent>
 #include <QMetaObject>
+#include <QMouseEvent>
 #include <QPushButton>
 #include <QScrollArea>
 #include <QVBoxLayout>

--- a/src/wave/scroll.cpp
+++ b/src/wave/scroll.cpp
@@ -102,7 +102,8 @@ void QCustomScroll::resizeEvent(QResizeEvent* event)
 {
     QWidget::resizeEvent(event);
     view->range = Token::PosToClock(width());
-    update();
+    updatebar(true);
+    QWidget::update();
 }
 
 void ScrollValue::notify()

--- a/src/wave/token.cpp
+++ b/src/wave/token.cpp
@@ -42,6 +42,11 @@ int64_t Token::PosToClock(int64_t value)
     return mipShiftLeft(int64_t(value * 2 / MainWindow::getScaling() / (bIsNaviWave ? 12 : 3)), mipmap_level);
 }
 
+double Token::ClocksPerPixel()
+{
+    return std::ldexp(2.0 / MainWindow::getScaling() / (bIsNaviWave ? 12 : 3), mipmap_level);
+}
+
 static float tonemap(float x)
 {
     x /= 255.0f;

--- a/src/wave/token.h
+++ b/src/wave/token.h
@@ -101,6 +101,7 @@ struct Token
     static const std::string_view GetName(int i) { return GetColor(i).name; }
 
     static int64_t PosToClock(int64_t value);
+    static double ClocksPerPixel();
     static int64_t GetTokenSize(int64_t value)
     {
         int64_t rounding = mipShiftLeft(1, mipmap_level) >> 1;

--- a/tests/input/appconfig_test.cpp
+++ b/tests/input/appconfig_test.cpp
@@ -61,16 +61,13 @@ TEST_F(AppConfigTest, AppliesFamilyDefaultsAndKeepsSameFamilyOverrides)
     EXPECT_TRUE(config.resolveLoadWaveStatesForTrace(9, "vega"));
 }
 
-TEST_F(AppConfigTest, PersistsGraphDetailOptions)
+TEST_F(AppConfigTest, PersistsPlotAlignment)
 {
     AppConfig& config = AppConfig::getInstance();
 
-    EXPECT_EQ(config.getLevelOfDetailBias(), 0);
     EXPECT_EQ(config.getPlotAlignment(), PlotAlignment::None);
 
-    config.setLevelOfDetailBias(-3);
     config.setPlotAlignment(PlotAlignment::Detail);
-    EXPECT_EQ(config.getLevelOfDetailBias(), -3);
     EXPECT_EQ(config.getPlotAlignment(), PlotAlignment::Detail);
 
     config.setPlotAlignment(PlotAlignment::Global);

--- a/tests/input/appconfig_test.cpp
+++ b/tests/input/appconfig_test.cpp
@@ -61,19 +61,6 @@ TEST_F(AppConfigTest, AppliesFamilyDefaultsAndKeepsSameFamilyOverrides)
     EXPECT_TRUE(config.resolveLoadWaveStatesForTrace(9, "vega"));
 }
 
-TEST_F(AppConfigTest, PersistsPlotAlignment)
-{
-    AppConfig& config = AppConfig::getInstance();
-
-    EXPECT_EQ(config.getPlotAlignment(), PlotAlignment::None);
-
-    config.setPlotAlignment(PlotAlignment::Detail);
-    EXPECT_EQ(config.getPlotAlignment(), PlotAlignment::Detail);
-
-    config.setPlotAlignment(PlotAlignment::Global);
-    EXPECT_EQ(config.getPlotAlignment(), PlotAlignment::Global);
-}
-
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);

--- a/tests/input/appconfig_test.cpp
+++ b/tests/input/appconfig_test.cpp
@@ -59,6 +59,22 @@ TEST_F(AppConfigTest, AppliesFamilyDefaultsAndKeepsSameFamilyOverrides)
     EXPECT_TRUE(config.resolveLoadWaveStatesForTrace(9, "vega"));
 }
 
+TEST_F(AppConfigTest, PersistsGraphDetailOptions)
+{
+    AppConfig& config = AppConfig::getInstance();
+
+    EXPECT_EQ(config.getLevelOfDetailBias(), 0);
+    EXPECT_EQ(config.getPlotAlignment(), PlotAlignment::None);
+
+    config.setLevelOfDetailBias(-3);
+    config.setPlotAlignment(PlotAlignment::Detail);
+    EXPECT_EQ(config.getLevelOfDetailBias(), -3);
+    EXPECT_EQ(config.getPlotAlignment(), PlotAlignment::Detail);
+
+    config.setPlotAlignment(PlotAlignment::Global);
+    EXPECT_EQ(config.getPlotAlignment(), PlotAlignment::Global);
+}
+
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);

--- a/tests/input/appconfig_test.cpp
+++ b/tests/input/appconfig_test.cpp
@@ -20,23 +20,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "config/appconfig.h"
 #include <gtest/gtest.h>
 #include <QCoreApplication>
 #include <QSettings>
 #include <QStandardPaths>
-#include "config/appconfig.h"
 
 class AppConfigTest : public ::testing::Test
 {
 protected:
-    void SetUp() override
+    // AppConfig keeps one QSettings instance alive for the process. Clearing the
+    // native settings store between tests invalidates that instance on Windows.
+    static void SetUpTestSuite()
     {
         QSettings settings("AMD", "Rocprof-Compute-Viewer");
         settings.clear();
         settings.sync();
     }
 
-    void TearDown() override
+    static void TearDownTestSuite()
     {
         QSettings settings("AMD", "Rocprof-Compute-Viewer");
         settings.clear();

--- a/tests/widgets/CMakeLists.txt
+++ b/tests/widgets/CMakeLists.txt
@@ -36,6 +36,18 @@ add_test(NAME plotcurve_test COMMAND plotcurve_test)
 set_tests_properties(plotcurve_test PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
 
 # ============================================================================
+# Options Layout Tests - vertical scrolling and fixed Graph Options sizing
+# ============================================================================
+add_executable(options_layout_test options_layout_test.cpp ${SRC_DIR}/mainwindow.ui)
+set_target_properties(options_layout_test PROPERTIES AUTOUIC ON AUTOUIC_SEARCH_PATHS ${SRC_DIR})
+target_include_directories(options_layout_test PRIVATE ${SRC_DIR})
+target_link_libraries(options_layout_test GTest::gtest Qt6::Widgets)
+rcv_enable_asan(options_layout_test)
+add_test(NAME options_layout_test COMMAND options_layout_test)
+set_tests_properties(
+    options_layout_test PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0;QT_QPA_PLATFORM=offscreen")
+
+# ============================================================================
 # TextElement Tests - Text line rendering with caching and hover states
 # ============================================================================
 add_executable(textelement_test textelement_test.cpp)

--- a/tests/widgets/options_layout_test.cpp
+++ b/tests/widgets/options_layout_test.cpp
@@ -1,0 +1,53 @@
+// MIT License
+//
+// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QMainWindow>
+#include <QScrollBar>
+#include "ui_mainwindow.h"
+
+TEST(OptionsLayoutTest, KeepsGraphOptionsHeightAndScrolls)
+{
+    QMainWindow window;
+    Ui::MainWindow ui;
+    ui.setupUi(&window);
+    ui.tabWidget_3->setCurrentWidget(ui.tab);
+
+    window.resize(1200, 900);
+    window.show();
+    QApplication::processEvents();
+    const int graph_options_height = ui.frame_5->height();
+
+    window.resize(800, 300);
+    QApplication::processEvents();
+
+    EXPECT_EQ(ui.frame_5->height(), graph_options_height);
+    EXPECT_GT(ui.options_scroll_area->verticalScrollBar()->maximum(), 0);
+}
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/widgets/plotcurve_test.cpp
+++ b/tests/widgets/plotcurve_test.cpp
@@ -322,19 +322,18 @@ TEST(PlotCurveTest, LODReducesDataSize)
 
 TEST(PlotAlignmentTest, AccountsForDifferentLabelColumnWidths)
 {
-    const PlotAlignmentReference reference{
-        .clock_at_left = 1000.0, .clocks_per_pixel = 4.0, .global_left = 84, .pixel_width = 916};
+    for (const double clocks_per_pixel : {0.25, 4.0, 1024.0})
+    {
+        const PlotAlignmentReference reference{
+            .clock_at_left = 1000.0, .clocks_per_pixel = clocks_per_pixel, .global_left = 84, .pixel_width = 916};
 
-    const auto range = alignedPlotRange(reference, 50, 944);
+        const auto range = alignedPlotRange(reference, 50, 944);
+        const double clock = reference.clock_at_left + 250 * clocks_per_pixel;
+        const double plot_pixel = 50 + (clock - range.start) / clocks_per_pixel;
+        const double reference_pixel = reference.global_left + (clock - reference.clock_at_left) / clocks_per_pixel;
 
-    EXPECT_DOUBLE_EQ(range.start, 864.0);
-    EXPECT_DOUBLE_EQ(range.end, 4640.0);
-
-    const double clock = 2000.0;
-    const double plot_pixel = 50 + (clock - range.start) / reference.clocks_per_pixel;
-    const double reference_pixel =
-        reference.global_left + (clock - reference.clock_at_left) / reference.clocks_per_pixel;
-    EXPECT_DOUBLE_EQ(plot_pixel, reference_pixel);
+        EXPECT_DOUBLE_EQ(plot_pixel, reference_pixel);
+    }
 }
 
 // ============================================================================

--- a/tests/widgets/plotcurve_test.cpp
+++ b/tests/widgets/plotcurve_test.cpp
@@ -162,9 +162,9 @@ struct PlotCurve
         return true;
     }
 
-    void UpdateLOD(float range, int width, bool bAuto)
+    void UpdateLOD(float range, int width, int bias)
     {
-        if (!bAuto || lods.size() < 2)
+        if (lods.size() < 2)
         {
             lod = 0;
             return;
@@ -176,7 +176,7 @@ struct PlotCurve
 
         while (lod < static_cast<int>(lods.size()) && lods.at(lod).min_interval < point_density_ratio) lod++;
 
-        lod--;
+        lod = std::clamp(lod - 1 + bias, 0, static_cast<int>(lods.size()) - 1);
     }
 };
 
@@ -289,16 +289,22 @@ TEST(PlotCurveTest, SetDataCreatesAtLeastOneLOD)
     EXPECT_GE(curve.lods.size(), 1u);
 }
 
-TEST(PlotCurveTest, UpdateLODWithAutoFalse)
+TEST(PlotCurveTest, LodBiasAdjustsAndClampsAutomaticLevel)
 {
     PlotCurve curve;
-    std::vector<WeightedPoint> data;
-    for (int i = 0; i < 200; i++) data.push_back({static_cast<float>(i), static_cast<float>(i % 10), 1.0f});
+    curve.lods.resize(5);
+    curve.lods[1].min_interval = 2.0f;
+    curve.lods[2].min_interval = 4.0f;
+    curve.lods[3].min_interval = 8.0f;
+    curve.lods[4].min_interval = 16.0f;
 
-    curve.SetData(std::move(data));
-    curve.lod = 5;
-
-    curve.UpdateLOD(100.0f, 100, false);
+    curve.UpdateLOD(800.0f, 100, 0);
+    EXPECT_EQ(curve.lod, 3);
+    curve.UpdateLOD(800.0f, 100, -2);
+    EXPECT_EQ(curve.lod, 1);
+    curve.UpdateLOD(800.0f, 100, 10);
+    EXPECT_EQ(curve.lod, 4);
+    curve.UpdateLOD(800.0f, 100, -10);
     EXPECT_EQ(curve.lod, 0);
 }
 

--- a/tests/widgets/plotcurve_test.cpp
+++ b/tests/widgets/plotcurve_test.cpp
@@ -28,6 +28,7 @@
 #include <cmath>
 #include <string>
 #include <vector>
+#include "graphics/plot_alignment.h"
 
 struct PlotPoint
 {
@@ -317,6 +318,23 @@ TEST(PlotCurveTest, LODReducesDataSize)
     curve.SetData(std::move(data));
 
     if (curve.lods.size() >= 2) EXPECT_LT(curve.lods[1].data.size(), curve.lods[0].data.size());
+}
+
+TEST(PlotAlignmentTest, AccountsForDifferentLabelColumnWidths)
+{
+    const PlotAlignmentReference reference{
+        .clock_at_left = 1000.0, .clocks_per_pixel = 4.0, .global_left = 84, .pixel_width = 916};
+
+    const auto range = alignedPlotRange(reference, 50, 944);
+
+    EXPECT_DOUBLE_EQ(range.start, 864.0);
+    EXPECT_DOUBLE_EQ(range.end, 4640.0);
+
+    const double clock = 2000.0;
+    const double plot_pixel = 50 + (clock - range.start) / reference.clocks_per_pixel;
+    const double reference_pixel =
+        reference.global_left + (clock - reference.clock_at_left) / reference.clocks_per_pixel;
+    EXPECT_DOUBLE_EQ(plot_pixel, reference_pixel);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Motivation

Added 3 radio buttons to select how plot views align their clocks to the Compute Unit or Global View tabs.
Replaced the LOD checkbox with LOD Bias option so users can get more detail or smooth out the plot without having to change zoom levels.

### Fixed

"Graph Options" getting squeezed vertically.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
